### PR TITLE
Implement NV12 to RGB24 color conversion with SYCL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,13 @@ uv venv && uv pip install torch~=2.10.0 -e ".[test]" \
   --index https://download.pytorch.org/whl/xpu -vv
 ```
 
+To try experimental SYCL color conversion kernel in [TorchCodec], build the project with `CXX=icpx` compiler:
+
+```
+CXX=icpx uv pip install torch~=2.10.0 -e ".[test]" \
+  --index https://download.pytorch.org/whl/xpu -vv
+```
+
 ## How to run linter
 
 ```

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/CMakeLists.txt
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/CMakeLists.txt
@@ -10,7 +10,7 @@ set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 REQUIRED)
 find_package(Torch REQUIRED)
 find_package(TorchCodec REQUIRED)
-find_package(Python3 EXACT COMPONENTS Development)
+find_package(Python3 COMPONENTS Development)
 
 if(DEFINED TORCHCODEC_XPU_DISABLE_COMPILE_WARNING_AS_ERROR AND TORCHCODEC_XPU_DISABLE_COMPILE_WARNING_AS_ERROR)
     set(TORCHCODEC_XPU_WERROR_OPTION "")
@@ -36,7 +36,16 @@ pkg_check_modules(LIBVA REQUIRED IMPORTED_TARGET libva)
 function(make_torchcodec_xpu_libraries torchcodec_variant)
     set(libname "xpu_ops${torchcodec_variant}")
     set(sources
+        ColorConversionKernel.cpp
         XpuDeviceInterface.cpp)
+
+    if($ENV{CXX} MATCHES "icpx")
+        set (WITH_SYCL_KERNELS ON)
+        message(STATUS "Intel compiler in use, Sycl support enabled")
+    else()
+        set (WITH_SYCL_KERNELS OFF)
+        message(STATUS "Non-Intel compiler in use, Sycl support disabled")
+    endif()
 
     python_add_library(${libname} MODULE WITH_SOABI ${sources})
     # Avoid adding the "lib" prefix which we already add explicitly.
@@ -52,6 +61,13 @@ function(make_torchcodec_xpu_libraries torchcodec_variant)
       torchcodec::ffmpeg${torchcodec_variant}
       PkgConfig::L0
     )
+
+    if(WITH_SYCL_KERNELS)
+        target_compile_definitions(${libname} PRIVATE WITH_SYCL_KERNELS=1)
+        target_compile_options(${libname} PRIVATE -fsycl)
+        target_link_options(${libname} PRIVATE -fsycl)
+    endif()
+
 
     install(
         TARGETS ${libname}

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/ColorConversionKernel.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/ColorConversionKernel.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Intel Corporation. All Rights Reserved.
+
+#ifdef WITH_SYCL_KERNELS
+
+#include "ColorConversionKernel.h"
+#include <algorithm> // For std::clamp
+
+namespace facebook::torchcodec {
+
+using float3x3 = std::array<sycl::float3, 3>;
+
+const float3x3 rgb_matrix_bt709 = {
+  sycl::float3{ 1.0, 0.0, 1.5748 },
+  sycl::float3{ 1.0, -0.187324, -0.468124 },
+  sycl::float3{ 1.0, 1.8556, 0.0 }
+};
+
+//const sycl::float3 rgb_matrix_bt601[3] = {
+//  { 1.0, 0.0, 1.402 },
+//  { 1.0, -0.344136, -0.714136 },
+//  { 1.0, 1.772, 0.0}
+//};
+
+// Helper function for the Intel Tile-Y offset calculation
+// Intel Y-Tiling uses COLUMN-MAJOR OWord (16 bytes) organization
+// Tile: 128 bytes wide × 32 rows = 4KB
+// Within tile: 8 OWords (16-byte columns) arranged column-by-column
+// Each OWord covers all 32 rows before moving to next OWord
+size_t get_tile_offset(int x, int y, int stride) {
+  const int TileW = 128;  // Tile width in bytes
+  const int TileH = 32;   // Tile height in rows
+  const int OWordSize = 16; // OWord = 16 bytes
+  const int TileSize = TileW * TileH;  // 4096 bytes per tile
+
+  // Which tile does this pixel belong to?
+  int tile_x = x / TileW;
+  int tile_y = y / TileH;
+
+  // Position within the tile
+  int x_in_tile = x % TileW;
+  int y_in_tile = y % TileH;
+
+  // Block position added to remove swap of 64-byte blocks in the tile (TileY XOR pattern)
+  int block_x = x_in_tile / 64;  // width of pixel blocks
+  int block_y = y_in_tile / 4;   // heigh of pixel blocks
+
+  // Y-Tiling: Column-major OWord layout
+  // OWord index (0-7): which 16-byte column within the tile
+  int oword_idx = x_in_tile / OWordSize;
+  // Offset within OWord (0-15)
+  int offset_in_oword = x_in_tile % OWordSize;
+
+  int sub_tile_size = OWordSize * 4;
+  int sub_tile_y = y_in_tile / 4;
+  int y_in_sub_tile = y_in_tile % 4;
+
+  // conditional to remove swap of 64-byte blocks in the tile (TileY XOR pattern)
+  if ((block_x ^ block_y ) & 0x1){
+    block_x ^= 1;
+    block_y ^= 1;
+
+    x_in_tile = block_x * 64 + (x_in_tile % 64);
+    y_in_tile = block_y * 4 + (y_in_tile % 4);
+
+    sub_tile_y = block_y;
+    y_in_sub_tile = y_in_tile % 4;
+
+    oword_idx = x_in_tile / OWordSize;
+    offset_in_oword = x_in_tile % 16;
+  }
+
+  int offset_in_tile = (sub_tile_y * TileW/OWordSize + oword_idx) * sub_tile_size + y_in_sub_tile * OWordSize + offset_in_oword;
+
+  // Number of tiles per row
+  int stride_in_tiles = stride / TileW;
+
+  // Final tiled offset
+  size_t tile_offset = (size_t)(tile_y * stride_in_tiles + tile_x) * TileSize;
+  return tile_offset + offset_in_tile;
+}
+
+sycl::uchar3 yuv2rgb(uint8_t y, uint8_t u, uint8_t v, bool fullrange, const float3x3 &rgb_matrix) {
+  sycl::float3 src;
+  if (fullrange) {
+    src = sycl::float3(y/255.0f, (u-128.0f)/255.0f - 0.5f, (v-128.0f)/255.0f - 0.5f);
+  } else {
+    src = sycl::float3((y-16.0f)/219.0f, (u-128.0f)/224.0f, (v-128.0f)/224.0f);
+  }
+
+  sycl::float3 fdst;
+  fdst.x() = sycl::dot(src, rgb_matrix[0]);
+  fdst.y() = sycl::dot(src, rgb_matrix[1]);
+  fdst.z() = sycl::dot(src, rgb_matrix[2]);
+
+  sycl::uchar3 dst;
+  dst.x() = (uint8_t)std::clamp(fdst[0] * 255.0f, 0.0f, 255.0f);
+  dst.y() = (uint8_t)std::clamp(fdst[1] * 255.0f, 0.0f, 255.0f);
+  dst.z() = (uint8_t)std::clamp(fdst[2] * 255.0f, 0.0f, 255.0f);
+  return dst;
+}
+
+struct NV12toRGBKernel {
+  const uint8_t* y_plane;
+  const uint8_t* uv_plane;
+  uint8_t* rgb_output;
+  int width;
+  int height;
+  int stride;
+  bool fullrange;
+  float3x3 rgb_matrix;
+
+  NV12toRGBKernel(
+      const uint8_t* y_plane,
+      const uint8_t* uv_plane,
+      uint8_t* rgb_output,
+      int width,
+      int height,
+      int stride,
+      bool fullrange,
+      const float3x3 &rgb_matrix):
+    y_plane(y_plane),
+    uv_plane(uv_plane),
+    rgb_output(rgb_output),
+    width(width),
+    height(height),
+    stride(stride),
+    fullrange(fullrange),
+    rgb_matrix(rgb_matrix)
+  {}
+
+  void operator()(sycl::id<2> idx) const {
+    int yx = idx[1];
+    int yy = idx[0];
+
+    if (yx >= width || yy >= height) {
+      return;
+    }
+
+    int ux = sycl::floor(yx/2.0);
+    int uy = sycl::floor(yy/2.0);
+
+    size_t tiled_idx_y = get_tile_offset(yx, yy, stride);
+    size_t tiled_idx_u = get_tile_offset(2*ux, uy, stride);
+    size_t tiled_idx_v = get_tile_offset(2*ux+1, uy, stride);
+
+    uint8_t y = y_plane[tiled_idx_y];
+    uint8_t u = uv_plane[tiled_idx_u];
+    uint8_t v = uv_plane[tiled_idx_v];
+
+    sycl::uchar3 rgb = yuv2rgb(y, u, v, fullrange, rgb_matrix);
+
+    int rgb_idx = 3 * (yy * width + yx);
+
+    rgb_output[rgb_idx + 0] = rgb.x();
+    rgb_output[rgb_idx + 1] = rgb.y();
+    rgb_output[rgb_idx + 2] = rgb.z();
+  }
+};
+
+void convertNV12ToRGB(
+    sycl::queue& queue,
+    const uint8_t* y_plane,
+    const uint8_t* uv_plane,
+    uint8_t* rgb_output,
+    int width,
+    int height,
+    int stride,
+    bool fullrange) {
+  queue.submit([&](sycl::handler& cgh) {
+    NV12toRGBKernel kernel(
+      y_plane, uv_plane, rgb_output,
+      width, height, stride,
+      fullrange, rgb_matrix_bt709);
+
+    cgh.parallel_for(
+        sycl::range<2>(height, width),
+        kernel);
+  });
+
+  queue.wait();
+}
+
+// This function is called during library initialization to ensure
+// the SYCL runtime registers the kernel associated with this type.
+void registerColorConversionKernel() {
+  // Creating a dummy pointer to the kernel type is often enough
+  // to force the compiler to emit the necessary RTTI/integration info.
+  // We use volatile to prevent optimization.
+  volatile size_t s = sizeof(NV12toRGBKernel);
+  (void)s;
+}
+
+} // namespace facebook::torchcodec
+#endif // WITH_SYCL_KERNELS

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/ColorConversionKernel.h
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/ColorConversionKernel.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#ifdef WITH_SYCL_KERNELS
+
+#include <sycl/sycl.hpp>
+#include <cstdint>
+
+namespace facebook::torchcodec {
+
+void convertNV12ToRGB(
+    sycl::queue& queue,
+    const uint8_t* y_plane,
+    const uint8_t* uv_plane,
+    uint8_t* rgb_output,
+    int width,
+    int height,
+    int stride,
+    bool fullrange = 1);
+
+// Anchor function to force kernel registration
+void registerColorConversionKernel();
+
+} // namespace facebook::torchcodec
+
+#endif // WITH_SYCL_KERNELS

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -2,6 +2,9 @@
 // Copyright (c) 2026 Intel Corporation. All Rights Reserved.
 
 #include <unistd.h>
+#include <stdlib.h>
+#include <string>
+#include <unordered_map>
 
 #include <level_zero/ze_api.h>
 #include <va/va_drmcommon.h>
@@ -9,6 +12,7 @@
 #include <ATen/DLConvertor.h>
 #include <c10/xpu/XPUStream.h>
 
+#include "ColorConversionKernel.h"
 #include "Cache.h"
 #include "FFMPEGCommon.h"
 #include "XpuDeviceInterface.h"
@@ -21,7 +25,10 @@ extern "C" {
 }
 
 namespace facebook::torchcodec {
+
 namespace {
+
+const char* USE_SYCL_KERNELS = std::getenv("USE_SYCL_KERNELS");
 
 static bool g_xpu = registerDeviceInterface(
     DeviceInterfaceKey(torch::kXPU),
@@ -33,6 +40,32 @@ const int MAX_XPU_GPUS = 128;
 const int MAX_CONTEXTS_PER_GPU_IN_CACHE = -1;
 PerGpuCache<AVBufferRef, Deleterp<AVBufferRef, void, av_buffer_unref>>
     g_cached_hw_device_ctxs(MAX_XPU_GPUS, MAX_CONTEXTS_PER_GPU_IN_CACHE);
+
+inline bool to_bool(std::string str) {
+    static const std::unordered_map<std::string, bool> bool_map = {
+        {"1", true},  {"0", false},
+        {"on", true}, {"off", false},
+        {"true", true}, {"false", false}
+    };
+
+    auto it = bool_map.find(str);
+    if (it != bool_map.end()) {
+        return it->second;
+    }
+    return false;
+}
+
+inline bool use_sycl_color_conversion_kernel() {
+#ifndef WITH_SYCL_KERNELS
+  return false;
+#else
+  if (!USE_SYCL_KERNELS) {
+    // By default attempt to convert with sycl (optimized path).
+    return true;
+  }
+  return to_bool(USE_SYCL_KERNELS);
+#endif
+}
 
 UniqueAVBufferRef getVaapiContext(const torch::Device& device) {
   enum AVHWDeviceType type = av_hwdevice_find_type_by_name("vaapi");
@@ -90,6 +123,14 @@ XpuDeviceInterface::XpuDeviceInterface(const torch::Device& device)
   torch::Tensor dummyTensorForXpuInitialization = torch::empty(
       {1}, torch::TensorOptions().dtype(torch::kUInt8).device(device_));
   ctx_ = getVaapiContext(device_);
+
+  if (use_sycl_color_conversion_kernel()) {
+    VLOG(1) << "XpuDeviceInterface initialized with SYCL kernel backend";
+    VLOG(1) << "Backend: SYCL_KERNEL (Direct NV12→RGB)";
+  } else {
+    VLOG(1) << "XpuDeviceInterface initialized with VAAPI filter graph backend";
+    VLOG(1) << "Backend: VAAPI_FILTER (Flexible, with scaling)";
+  }
 }
 
 XpuDeviceInterface::~XpuDeviceInterface() {
@@ -137,6 +178,8 @@ void deleter(DLManagedTensor* self) {
   std::unique_ptr<DLManagedTensor> tensor(self);
   std::unique_ptr<xpuManagerCtx> context((xpuManagerCtx*)self->manager_ctx);
   zeMemFree(context->zeCtx, self->dl_tensor.data);
+  free(self->dl_tensor.shape);
+  free(self->dl_tensor.strides);
 }
 
 torch::Tensor AVFrameToTensor(
@@ -162,7 +205,7 @@ torch::Tensor AVFrameToTensor(
   TORCH_CHECK(
       desc.layers[0].num_planes == 1,
       "Expected 1 plane, got ",
-      desc.num_layers);
+      desc.layers[0].num_planes);
 
   std::unique_ptr<xpuManagerCtx> context = std::make_unique<xpuManagerCtx>();
   ze_device_handle_t ze_device{};
@@ -201,7 +244,11 @@ torch::Tensor AVFrameToTensor(
   close(desc.objects[0].fd);
 
   std::unique_ptr<DLManagedTensor> dl_dst = std::make_unique<DLManagedTensor>();
-  int64_t shape[3] = {desc.height, desc.width, 4};
+  int64_t* shape = (int64_t*)malloc(3*sizeof(int64_t));
+
+  shape[0] = frame->height;
+  shape[1] = frame->width;
+  shape[2] = 4;
 
   context->avFrame.reset(av_frame_alloc());
   TORCH_CHECK(context->avFrame.get(), "Failed to allocate AVFrame");
@@ -266,6 +313,23 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
   }
 
   auto start = std::chrono::high_resolution_clock::now();
+  if (!convertAVFrameToFrameOutput_SYCL(avFrame, dst)) {
+    convertAVFrameToFrameOutput_FilterGraph(avFrame, dst);
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+
+  std::chrono::duration<double, std::micro> duration = end - start;
+  VLOG(9) << "Conversion of frame height=" << frameDims.height << " width=" << frameDims.width
+          << " took: " << duration.count() << "us" << std::endl;
+}
+
+void XpuDeviceInterface::convertAVFrameToFrameOutput_FilterGraph(
+    UniqueAVFrame& avFrame,
+    torch::Tensor& dst) {
+  VLOG(1) << "Using VAAPI filter graph backend for conversion";
+  auto frameDims = FrameDims(avFrame->height, avFrame->width);
+
   // We need to compare the current frame context with our previous frame
   // context. If they are different, then we need to re-create our colorspace
   // conversion objects. We create our colorspace conversion objects late so
@@ -308,12 +372,81 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
 
   torch::Tensor dst_rgb4 = AVFrameToTensor(device_, filteredAVFrame);
   dst.copy_(dst_rgb4.narrow(2, 0, 3));
+}
 
-  auto end = std::chrono::high_resolution_clock::now();
+bool XpuDeviceInterface::convertAVFrameToFrameOutput_SYCL(
+    [[maybe_unused]] UniqueAVFrame& frame,
+    [[maybe_unused]] torch::Tensor& dst) {
+  bool converted = false;
+  if (!use_sycl_color_conversion_kernel()) {
+    return converted;
+  }
 
-  std::chrono::duration<double, std::micro> duration = end - start;
-  VLOG(9) << "Conversion of frame height=" << frameDims.height << " width=" << frameDims.width
-          << " took: " << duration.count() << "us" << std::endl;
+#ifdef WITH_SYCL_KERNELS
+  VLOG(1) << "Using SYCL kernel backend for conversion";
+  TORCH_CHECK_EQ(frame->format, AV_PIX_FMT_VAAPI);
+  VADRMPRIMESurfaceDescriptor desc{};
+  VAStatus sts = vaExportSurfaceHandle(
+      getVaDisplayFromAV(frame.get()),
+      (VASurfaceID)(uintptr_t)frame->data[3],
+      VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2,
+      VA_EXPORT_SURFACE_READ_ONLY,
+      &desc);
+  TORCH_CHECK(
+      sts == VA_STATUS_SUCCESS,
+      "vaExportSurfaceHandle failed: ",
+      vaErrorStr(sts));
+
+  TORCH_CHECK(desc.num_objects == 1, "Expected 1 fd, got ", desc.num_objects);
+  std::unique_ptr<xpuManagerCtx> context = std::make_unique<xpuManagerCtx>();
+  ze_device_handle_t ze_device{};
+  sycl::queue queue = c10::xpu::getCurrentXPUStream(device_.index());
+  queue
+      .submit([&](sycl::handler& cgh) {
+        cgh.host_task([&](const sycl::interop_handle& ih) {
+          context->zeCtx =
+              ih.get_native_context<sycl::backend::ext_oneapi_level_zero>();
+          ze_device =
+              ih.get_native_device<sycl::backend::ext_oneapi_level_zero>();
+        });
+      })
+      .wait();
+
+  ze_external_memory_import_fd_t import_fd_desc{};
+  import_fd_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMPORT_FD;
+  import_fd_desc.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
+  import_fd_desc.fd = desc.objects[0].fd;
+
+  ze_device_mem_alloc_desc_t alloc_desc{};
+  alloc_desc.pNext = &import_fd_desc;
+  void* usm_ptr = nullptr;
+
+  ze_result_t res = zeMemAllocDevice(
+      context->zeCtx,
+      &alloc_desc,
+      desc.objects[0].size,
+      0,
+      ze_device,
+      &usm_ptr);
+  TORCH_CHECK(
+      res == ZE_RESULT_SUCCESS, "Failed to import fd=", desc.objects[0].fd);
+
+  close(desc.objects[0].fd);
+
+  convertNV12ToRGB(
+      queue,
+      (uint8_t*)usm_ptr + desc.layers[0].offset[0],
+      (uint8_t*)usm_ptr + desc.layers[1].offset[0],
+      (uint8_t*)dst.data_ptr(),
+      frame->width,
+      frame->height,
+      desc.layers[0].pitch[0],
+      false);
+
+  zeMemFree(context->zeCtx, usm_ptr);
+  converted = true;
+#endif
+  return converted;
 }
 
 // inspired by https://github.com/FFmpeg/FFmpeg/commit/ad67ea9

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
@@ -49,6 +49,16 @@ class XpuDeviceInterface : public DeviceInterface {
   // Used to know whether a new FilterGraphContext should
   // be created before decoding a new frame.
   FiltersContext prevFiltersContext_;
+
+  // Optimized conversion. Return value indicates if conversion was
+  // successfull.
+  bool convertAVFrameToFrameOutput_SYCL(
+      UniqueAVFrame& avFrame,
+      torch::Tensor& dst);
+  // Fallback conversion if optimized path is not available.
+  void convertAVFrameToFrameOutput_FilterGraph(
+      UniqueAVFrame& avFrame,
+      torch::Tensor& dst);
 };
 
 } // namespace facebook::torchcodec


### PR DESCRIPTION
See ffmpeg color yuv2rgb color conversion reference:
* https://github.com/FFmpeg/FFmpeg/blob/a5d4c398b411a00ac09d8fe3b66117222323844c/libavfilter/opencl/colorspace_common.cl#L111

Color conversion matrix copied from the ffmpeg internal output of:

```
ff_fill_rgb2yuv_table(av_csp_luma_coeffs_from_avcsp(color_space), rgb2yuv);
ff_matrix_invert_3x3(rgb2yuv, yuv2rgb);
```

with color space `AVCOL_PRI_BT470BG` and `AVCOL_PRI_BT709`.

Reference results for the nasa clip from torchcodec:

```
ffmpeg -i nasa_13013.mp4 -vf "scale=480:270:sws_flags=bilinear,format=rgb24" -y nasa_13013_ffmpeg_cpu.rgb
ffmpeg -f rawvideo -pix_fmt rgb24 -s:v 480x270 -i nasa_13013_xpu.rgb -f rawvideo -pix_fmt rgb24 -s:v 480x270 -i nasa_13013_ffmpeg_cpu.rgb -filter_complex "psnr"

PSNR r:52.915639 g:48.554012 b:52.363531 average:50.815521 min:49.467900 max:51.852806
```

CC: @eromomon 