### PR TITLE
Add CPU fallback for torchcodec-xpu on XPU devices without media processing support

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -29,6 +29,7 @@ jobs:
         sudo add-apt-repository -y ppa:kobuk-team/intel-graphics
         sudo apt-get install -y \
           libva-dev \
+          libva-drm2
           libze-dev \
           libze-intel-gpu1 \
           intel-ocloc

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
         sudo add-apt-repository -y ppa:kobuk-team/intel-graphics
         sudo apt-get install -y \
           libva-dev \
-          libva-drm2
+          libva-drm2 \
           libze-dev \
           libze-intel-gpu1 \
           intel-ocloc

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -29,7 +29,6 @@ jobs:
         sudo add-apt-repository -y ppa:kobuk-team/intel-graphics
         sudo apt-get install -y \
           libva-dev \
-          libva-drm2 \
           libze-dev \
           libze-intel-gpu1 \
           intel-ocloc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y \
           libva2 \
+          libva-drm2 \
           libze1
     - name: 'Install FFmpeg ${{ matrix.ffmpeg-version }}'
       run: |

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/CMakeLists.txt
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(L0 REQUIRED IMPORTED_TARGET level-zero)
 pkg_check_modules(LIBVA REQUIRED IMPORTED_TARGET libva)
+pkg_check_modules(LIBVA_DRM REQUIRED IMPORTED_TARGET libva-drm)
 
 if (NOT "$ENV{TORCH_XPU_ARCH_LIST}" STREQUAL "")
     set(TORCH_XPU_ARCH_LIST "$ENV{TORCH_XPU_ARCH_LIST}")
@@ -88,6 +89,7 @@ function(make_torchcodec_xpu_libraries torchcodec_variant)
       torchcodec::ffmpeg${torchcodec_variant}
       PkgConfig::LIBVA
       PkgConfig::L0
+      PkgConfig::LIBVA_DRM
     )
 
     if(WITH_SYCL_KERNELS)

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -203,6 +203,7 @@ XpuDeviceInterface::XpuDeviceInterface(const torch::Device& device)
         << " does not support VAAPI media decode. "
         << " Hardware video decoding unavailable, the framework will "
         << " fall back to CPU";
+    cpuFallback_ = std::make_unique<CpuDeviceInterface>(torch::Device(torch::kCPU));
     return;
   }
 
@@ -231,6 +232,13 @@ void XpuDeviceInterface::initialize(
     [[maybe_unused]] const UniqueDecodingAVFormatContext& avFormatCtx,
     [[maybe_unused]] const SharedAVCodecContext& codecContext) {
   TORCH_CHECK(avStream != nullptr, "avStream is null");
+  // to implement CPU fallback
+  if (cpuFallback_) {
+    codecContext_ = codecContext;
+    timeBase_ = avStream->time_base;
+    cpuFallback_->initialize(avStream, avFormatCtx, codecContext);
+    return;
+  }
   codecContext_ = codecContext;
   timeBase_ = avStream->time_base;
 }
@@ -239,11 +247,20 @@ void XpuDeviceInterface::initializeVideo(
     const VideoStreamOptions& videoStreamOptions,
     [[maybe_unused]] const std::vector<std::unique_ptr<Transform>>& transforms,
     [[maybe_unused]] const std::optional<FrameDims>& resizedOutputDims) {
+  if (cpuFallback_) {
+    cpuFallback_->initializeVideo(videoStreamOptions, transforms, resizedOutputDims);
+    return;
+  }
   videoStreamOptions_ = videoStreamOptions;
 }
 
 void XpuDeviceInterface::registerHardwareDeviceWithCodec(
     AVCodecContext* codecContext) {
+  // To implement CPU fallback
+  if(!hasMediaDecodec_) {
+     return;
+  }
+
   TORCH_CHECK(ctx_, "FFmpeg HW device has not been initialized");
   TORCH_CHECK(codecContext != nullptr, "codecContext is null");
   codecContext->hw_device_ctx = av_buffer_ref(ctx_.get());
@@ -377,6 +394,16 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
     std::optional<torch::Tensor> preAllocatedOutputTensor) {
   // TODO: consider to copy handling of CPU frame from CUDA
   // TODO: consider to copy NV12 format check from CUDA
+  // To implement CPU fallback
+  if (cpuFallback_) {
+    cpuFallback_->convertAVFrameToFrameOutput(avFrame, frameOutput, std::nullopt);
+    if (preAllocatedOutputTensor.has_value()){
+      preAllocatedOutputTensor.value().copy_(frameOutput.data);
+      frameOutput.data = preAllocatedOutputTensor.value();
+    }
+    return;
+  }
+
   TORCH_CHECK(
       avFrame->format == AV_PIX_FMT_VAAPI,
       "Expected format to be AV_PIX_FMT_VAAPI, got " +
@@ -546,6 +573,10 @@ bool XpuDeviceInterface::convertAVFrameToFrameOutput_SYCL(
 std::optional<const AVCodec*> XpuDeviceInterface::findCodec(
     const AVCodecID& codecId,
     bool isDecoder) {
+
+  if (!hasMediaDecodec_){
+    return std::nullopt;
+  }
   void* i = nullptr;
   const AVCodec* codec = nullptr;
   while ((codec = av_codec_iterate(&i)) != nullptr) {

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -9,6 +9,11 @@
 #include <level_zero/ze_api.h>
 #include <va/va_drmcommon.h>
 
+#include <va/va.h>
+#include <va/va_drm.h>
+#include <fcntl.h>
+#include <vector>
+
 #include <ATen/DLConvertor.h>
 #include <c10/xpu/XPUStream.h>
 
@@ -73,6 +78,56 @@ bool has_fp64(const torch::Device& device) {
   return syclDevice.has(sycl::aspect::fp64);
 }
 
+// function to find Media Codec
+static bool probeVaapiMediaCodec(const std::string& renderD){
+  int fd = open(renderD.c_str(), O_RDWR);
+  if (fd < 0){
+    printf("ProbeVaapiMediaCodec: Failed to open render node");
+    return false;
+  }
+  
+  VADisplay dpy = vaGetDisplayDRM(fd);
+  if (!dpy){
+    close(fd);
+    printf("ProbeVaapiMediaCodec: Failed to get Display DRM from render node");
+    return false;
+  }
+
+  int major = 0, minor = 0;
+  VAStatus sts = vaInitialize(dpy, &major, &minor);
+  if (sts!= VA_STATUS_SUCCESS){
+    vaTerminate(dpy);
+    close(fd);
+    printf("ProbeVaapiMediaCodec: Failed to initialize VAAPI");
+    return false;
+  }
+
+  int maxEntrypoints = vaMaxNumEntrypoints(dpy);
+  std::vector<VAEntrypoint> entrypoints(maxEntrypoints);
+  int numEntrypoints = 0;
+  sts = vaQueryConfigEntrypoints(dpy, VAProfileH264Main, entrypoints.data(), &numEntrypoints);
+
+  
+  // Checks for H.264 media codec
+  bool hasMediaDecodec = false;
+  if (sts == VA_STATUS_SUCCESS) {
+    for (int i = 0 ; i < numEntrypoints; ++i) {
+      if (entrypoints[i] == VAEntrypointVLD){
+        hasMediaDecodec = true;
+        break;
+      }
+    }
+  }
+
+  vaTerminate(dpy);
+  close(fd);
+
+  printf("ProbeVaapiMediaCodec: VAAPI media decode has %s\n", hasMediaDecodec ? "been found" : "not been found");
+  return hasMediaDecodec;
+
+}
+
+
 UniqueAVBufferRef getVaapiContext(const torch::Device& device) {
   enum AVHWDeviceType type = av_hwdevice_find_type_by_name("vaapi");
   TORCH_CHECK(type != AV_HWDEVICE_TYPE_NONE, "Failed to find vaapi device");
@@ -128,6 +183,30 @@ XpuDeviceInterface::XpuDeviceInterface(const torch::Device& device)
   // This is a dummy tensor to initialize the xpu context.
   torch::Tensor dummyTensorForXpuInitialization = torch::empty(
       {1}, torch::TensorOptions().dtype(torch::kUInt8).device(device_));
+  
+  // Review codec properties 
+  has_fp64_ = has_fp64(device);
+  VLOG(1) << "Device supports FP64: " << has_fp64_;
+
+  int deviceIndex = getDeviceIndex(device_);
+  std::string renderD = "/dev/dri/renderD128";
+  sycl::device syclDevice = c10::xpu::get_raw_device(deviceIndex);
+  if (syclDevice.has(sycl::aspect::ext_intel_pci_address)){
+    auto BDF = syclDevice.get_info<sycl::ext::intel::info::device::pci_address>();
+    renderD = "/dev/dri/by-path/pci-" + BDF + "-render";
+  }
+  hasMediaDecodec_ = probeVaapiMediaCodec(renderD);
+
+  if (!hasMediaDecodec_){
+    LOG(WARNING)
+        <<" XPU at device " << renderD
+        << " does not support VAAPI media decode. "
+        << " Hardware video decoding unavailable, the framework will "
+        << " fall back to CPU";
+    return;
+  }
+
+  
   ctx_ = getVaapiContext(device_);
 
   if (use_sycl_color_conversion_kernel()) {
@@ -138,8 +217,7 @@ XpuDeviceInterface::XpuDeviceInterface(const torch::Device& device)
     VLOG(1) << "Backend: VAAPI_FILTER (Flexible, with scaling)";
   }
 
-  has_fp64_ = has_fp64(device);
-  VLOG(1) << "Device supports FP64: " << has_fp64_;
+  
 }
 
 XpuDeviceInterface::~XpuDeviceInterface() {

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
@@ -43,6 +43,8 @@ class XpuDeviceInterface : public DeviceInterface {
   AVRational timeBase_;
   bool has_fp64_;
 
+  bool hasMediaDecodec_ = false;
+
   UniqueAVBufferRef ctx_;
 
   std::unique_ptr<FilterGraph> filterGraphContext_;

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "DeviceInterface.h"
+#include "CpuDeviceInterface.h"
 #include "FilterGraph.h"
 
 namespace facebook::torchcodec {
@@ -62,6 +63,9 @@ class XpuDeviceInterface : public DeviceInterface {
   void convertAVFrameToFrameOutput_FilterGraph(
       UniqueAVFrame& avFrame,
       torch::Tensor& dst);
+
+  // To implment Cpu fallback
+  std::unique_ptr<CpuDeviceInterface> cpuFallback_;
 };
 
 } // namespace facebook::torchcodec


### PR DESCRIPTION
fixes #13 

Add CPU fallback for torchcodec-xpu package in case media processing is not supported on the XPU device.
