### PR TITLE
torchcodec-xpu: CPU fallback

### DIFF
--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -172,48 +172,22 @@ void convertSWFrameToRGB_sws(
   const int height = avFrame->height;
   auto srcFormat = static_cast<AVPixelFormat>(avFrame->format);
 
-  SwsContext* sws = sws_getContext(
-      width,
-      height,
-      srcFormat,
-      width,
-      height,
-      AV_PIX_FMT_RGB24,
-      SWS_BILINEAR,
-      nullptr,
-      nullptr,
-      nullptr);
+  SwsContext* sws = sws_getContext(width, height, srcFormat, width, height,
+      AV_PIX_FMT_RGB24, SWS_BILINEAR, nullptr, nullptr, nullptr);
   TORCH_CHECK(
-      sws != nullptr,
-      "sws_getContext failed for ",
-      av_get_pix_fmt_name(srcFormat),
-      " -> RGB24 at ",
-      width,
-      "x",
+      sws != nullptr, "sws_getContext failed for ", av_get_pix_fmt_name(srcFormat),
+      " -> RGB24 at ", width, "x",
       height);
 
-  uint8_t* dstData[4] = {
-      static_cast<uint8_t*>(dstRGB_CPU.mutable_data_ptr()),
-      nullptr,
-      nullptr,
-      nullptr};
+  uint8_t* dstData[4] = {static_cast<uint8_t*>(dstRGB_CPU.mutable_data_ptr()),
+      nullptr, nullptr, nullptr};
   int dstLinesize[4] = {width * 3, 0, 0, 0};
 
-  int scaled = sws_scale(
-      sws,
-      avFrame->data,
-      avFrame->linesize,
-      0,
-      height,
-      dstData,
-      dstLinesize);
+  int scaled = sws_scale(sws, avFrame->data, avFrame->linesize, 0,
+      height, dstData, dstLinesize);
   sws_freeContext(sws);
   TORCH_CHECK(
-      scaled == height,
-      "sws_scale produced ",
-      scaled,
-      " lines, expected ",
-      height);
+      scaled == height, "sws_scale produced ", scaled, " lines, expected ", height);
 }
 
 } // namespace xpu
@@ -371,12 +345,7 @@ torch::stable::Tensor AVFrameToTensor(
   void* usm_ptr = nullptr;
 
   ze_result_t res = zeMemAllocDevice(
-      context->zeCtx,
-      &alloc_desc,
-      desc.objects[0].size,
-      0,
-      ze_device,
-      &usm_ptr);
+      context->zeCtx, &alloc_desc, desc.objects[0].size, 0, ze_device, &usm_ptr);
   TORCH_CHECK(
       res == ZE_RESULT_SUCCESS, "Failed to import fd=", desc.objects[0].fd);
 

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -18,8 +18,6 @@
 #include "XpuDeviceInterface.h"
 
 extern "C" {
-#include <libavfilter/buffersink.h>
-#include <libavfilter/buffersrc.h>
 #include <libavutil/hwcontext_vaapi.h>
 #include <libavutil/pixdesc.h>
 #include <libswscale/swscale.h>
@@ -73,39 +71,6 @@ bool has_fp64(const StableDevice& device) {
   return syclDevice.has(sycl::aspect::fp64);
 }
 
-UniqueAVBufferRef getVaapiContext(const StableDevice& device) {
-  enum AVHWDeviceType type = av_hwdevice_find_type_by_name("vaapi");
-  if (type == AV_HWDEVICE_TYPE_NONE) {
-    LOG(WARNING) << "VAAPI hwdevice type not found in this FFmpeg build.";
-    return UniqueAVBufferRef(nullptr);
-  }
-  int deviceIndex = getDeviceIndex(device);
-
-  UniqueAVBufferRef hw_device_ctx = g_cached_hw_device_ctxs.get(device);
-  if (hw_device_ctx) {
-    return hw_device_ctx;
-  }
-
-  std::string renderD = "/dev/dri/renderD128";
-
-  sycl::device syclDevice = c10::xpu::get_raw_device(deviceIndex);
-  if (syclDevice.has(sycl::aspect::ext_intel_pci_address)) {
-    auto BDF =
-        syclDevice.get_info<sycl::ext::intel::info::device::pci_address>();
-    renderD = "/dev/dri/by-path/pci-" + BDF + "-render";
-  }
-
-  AVBufferRef* ctx = nullptr;
-  int err = av_hwdevice_ctx_create(&ctx, type, renderD.c_str(), nullptr, 0);
-  if (err < 0) {
-    LOG(WARNING) << "Failed to create VAAPI device context on " << renderD
-                 << ": " << getFFMPEGErrorStringFromErrorCode(err)
-                 << "; all codecs will fall back to CPU.";
-    return UniqueAVBufferRef(nullptr);
-  }
-  return UniqueAVBufferRef(ctx);
-}
-
 // Resolve the VAAPI render-node path this XPU device should open. Duplicates
 // getVaapiContext's internal logic so we can surface the path for diagnostics
 // even when getVaapiContext returns null.
@@ -121,14 +86,63 @@ std::string resolveRenderD(const StableDevice& device) {
   return renderD;
 }
 
+
+UniqueAVBufferRef getVaapiContext(const StableDevice& device) {
+  enum AVHWDeviceType type = av_hwdevice_find_type_by_name("vaapi");
+  if (type == AV_HWDEVICE_TYPE_NONE) {
+    VLOG(1) << "VAAPI hwdevice type not found in this FFmpeg build.";
+    return UniqueAVBufferRef(nullptr);
+  }
+  // int deviceIndex = getDeviceIndex(device);
+
+  UniqueAVBufferRef hw_device_ctx = g_cached_hw_device_ctxs.get(device);
+  if (hw_device_ctx) {
+    return hw_device_ctx;
+  }
+
+  //std::string renderD = "/dev/dri/renderD128";
+
+  //sycl::device syclDevice = c10::xpu::get_raw_device(deviceIndex);
+  //if (syclDevice.has(sycl::aspect::ext_intel_pci_address)) {
+  //  auto BDF =
+  //      syclDevice.get_info<sycl::ext::intel::info::device::pci_address>();
+  //  renderD = "/dev/dri/by-path/pci-" + BDF + "-render";
+  //}
+
+  std::string renderD = resolveRenderD(device);
+
+  AVBufferRef* ctx = nullptr;
+  int err = av_hwdevice_ctx_create(&ctx, type, renderD.c_str(), nullptr, 0);
+  if (err < 0) {
+    VLOG(1) << "Failed to create VAAPI device context on " << renderD
+            << ": " << getFFMPEGErrorStringFromErrorCode(err)
+            << "; all codecs will fall back to CPU.";
+    return UniqueAVBufferRef(nullptr);
+  }
+  return UniqueAVBufferRef(ctx);
+}
+
+// // Resolve the VAAPI render-node path this XPU device should open. Duplicates
+// // getVaapiContext's internal logic so we can surface the path for diagnostics
+// // even when getVaapiContext returns null.
+// std::string resolveRenderD(const StableDevice& device) {
+//   std::string renderD = "/dev/dri/renderD128";
+//   int deviceIndex = getDeviceIndex(device);
+//   sycl::device syclDevice = c10::xpu::get_raw_device(deviceIndex);
+//   if (syclDevice.has(sycl::aspect::ext_intel_pci_address)) {
+//     auto BDF =
+//         syclDevice.get_info<sycl::ext::intel::info::device::pci_address>();
+//     renderD = "/dev/dri/by-path/pci-" + BDF + "-render";
+//   }
+//   return renderD;
+// }
+
 // Returns true if FFmpeg was built with VAAPI HW decode support for this
 // codec. Physical device capability is validated lazily at the first decoded
 // frame via the silent-SW-fallback detection in convertAVFrameToFrameOutput.
 // The AVBufferRef argument is intentionally unused; this is a pure FFmpeg
 // metadata check.
-bool deviceSupportsHWDecode(
-    AVBufferRef* /*hw_device_ctx*/,
-    AVCodecID codec_id) {
+bool deviceSupportsHWDecode(AVCodecID codec_id) {
   const AVCodec* decoder = avcodec_find_decoder(codec_id);
   if (!decoder) {
     return false;
@@ -264,10 +278,10 @@ void XpuDeviceInterface::registerHardwareDeviceWithCodec(
     AVCodecContext* codecContext) {
   TORCH_CHECK(codecContext != nullptr, "codecContext is null");
   if (!ctx_ ||
-      !xpu::deviceSupportsHWDecode(ctx_.get(), codecContext->codec_id)) {
-    LOG(WARNING) << "No VAAPI HW decode for codec "
-                 << avcodec_get_name(codecContext->codec_id) << " on device "
-                 << renderD_ << "; falling back to CPU for this stream.";
+      !xpu::deviceSupportsHWDecode(codecContext->codec_id)) {
+    VLOG(1) << "No VAAPI HW decode for codec "
+            << avcodec_get_name(codecContext->codec_id) << " on device "
+            << renderD_ << "; falling back to CPU for this stream.";
     hwDecodeActiveForCurrentStream_ = false;
     return;
   }
@@ -407,11 +421,11 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
   // blocks, so FFmpeg silently falls back to software decode on the first
   // packet.
   if (hwDecodeActiveForCurrentStream_ && avFrame->format != AV_PIX_FMT_VAAPI) {
-    LOG(WARNING) << "Expected VAAPI frame but got SW format "
-                 << av_get_pix_fmt_name((AVPixelFormat)avFrame->format)
-                 << " on device " << renderD_
-                 << "; device has no HW decode engine for this codec."
-                 << " Switching stream to CPU path.";
+    VLOG(1) << "Expected VAAPI frame but got SW format "
+            << av_get_pix_fmt_name((AVPixelFormat)avFrame->format)
+            << " on device " << renderD_
+            << "; device has no HW decode engine for this codec."
+            << " Switching stream to CPU path.";
     hwDecodeActiveForCurrentStream_ = false;
   }
 
@@ -457,7 +471,7 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
         intArrayRefToString(shape));
     dst = preAllocatedOutputTensor.value();
   } else {
-    // Excplicitly load the version defined in facebook::torchcodec::xpu
+    // Explicitly load the version defined in facebook::torchcodec::xpu
     // namespace as facebook::torchcodec defines the same but with the linkage
     // type which we can't use.
     dst = xpu::allocateEmptyHWCTensor(frameDims, device_);
@@ -606,7 +620,7 @@ bool XpuDeviceInterface::convertAVFrameToFrameOutput_SYCL(
 
 // inspired by https://github.com/FFmpeg/FFmpeg/commit/ad67ea9
 // we have to do this because of an FFmpeg bug where hardware decoding is not
-// appropriately set, so we just go off and find the matching codec for the CUDA
+// appropriately set, so we just go off and find the matching codec for the XPU
 // device
 std::optional<const AVCodec*> XpuDeviceInterface::findCodec(
     const AVCodecID& codecId,

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -397,6 +397,7 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
             << " on device " << renderD_
             << "; device has no HW decode engine for this codec."
             << " Switching stream to CPU path.";
+    std::string("[XPU Device Interface] Using CPU fallback.");
     hwDecodeActiveForCurrentStream_ = false;
   }
 
@@ -416,7 +417,7 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
       torch::stable::copy_(preAllocatedOutputTensor.value(), cpuRGB);
       frameOutput.data = preAllocatedOutputTensor.value();
     } else {
-      frameOutput.data = cpuRGB;
+      frameOutput.data = torch::stable::to(cpuRGB, device_);
     }
     return;
   }

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -71,9 +71,7 @@ bool has_fp64(const StableDevice& device) {
   return syclDevice.has(sycl::aspect::fp64);
 }
 
-// Resolve the VAAPI render-node path this XPU device should open. Duplicates
-// getVaapiContext's internal logic so we can surface the path for diagnostics
-// even when getVaapiContext returns null.
+// Resolves the VAAPI render-node path this XPU device should open.
 std::string resolveRenderD(const StableDevice& device) {
   std::string renderD = "/dev/dri/renderD128";
   int deviceIndex = getDeviceIndex(device);
@@ -93,21 +91,11 @@ UniqueAVBufferRef getVaapiContext(const StableDevice& device) {
     VLOG(1) << "VAAPI hwdevice type not found in this FFmpeg build.";
     return UniqueAVBufferRef(nullptr);
   }
-  // int deviceIndex = getDeviceIndex(device);
 
   UniqueAVBufferRef hw_device_ctx = g_cached_hw_device_ctxs.get(device);
   if (hw_device_ctx) {
     return hw_device_ctx;
   }
-
-  //std::string renderD = "/dev/dri/renderD128";
-
-  //sycl::device syclDevice = c10::xpu::get_raw_device(deviceIndex);
-  //if (syclDevice.has(sycl::aspect::ext_intel_pci_address)) {
-  //  auto BDF =
-  //      syclDevice.get_info<sycl::ext::intel::info::device::pci_address>();
-  //  renderD = "/dev/dri/by-path/pci-" + BDF + "-render";
-  //}
 
   std::string renderD = resolveRenderD(device);
 
@@ -122,26 +110,9 @@ UniqueAVBufferRef getVaapiContext(const StableDevice& device) {
   return UniqueAVBufferRef(ctx);
 }
 
-// // Resolve the VAAPI render-node path this XPU device should open. Duplicates
-// // getVaapiContext's internal logic so we can surface the path for diagnostics
-// // even when getVaapiContext returns null.
-// std::string resolveRenderD(const StableDevice& device) {
-//   std::string renderD = "/dev/dri/renderD128";
-//   int deviceIndex = getDeviceIndex(device);
-//   sycl::device syclDevice = c10::xpu::get_raw_device(deviceIndex);
-//   if (syclDevice.has(sycl::aspect::ext_intel_pci_address)) {
-//     auto BDF =
-//         syclDevice.get_info<sycl::ext::intel::info::device::pci_address>();
-//     renderD = "/dev/dri/by-path/pci-" + BDF + "-render";
-//   }
-//   return renderD;
-// }
-
 // Returns true if FFmpeg was built with VAAPI HW decode support for this
 // codec. Physical device capability is validated lazily at the first decoded
 // frame via the silent-SW-fallback detection in convertAVFrameToFrameOutput.
-// The AVBufferRef argument is intentionally unused; this is a pure FFmpeg
-// metadata check.
 bool deviceSupportsHWDecode(AVCodecID codec_id) {
   const AVCodec* decoder = avcodec_find_decoder(codec_id);
   if (!decoder) {
@@ -450,8 +421,6 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
     return;
   }
 
-  // TODO: consider to copy handling of CPU frame from CUDA
-  // TODO: consider to copy NV12 format check from CUDA
   TORCH_CHECK(
       avFrame->format == AV_PIX_FMT_VAAPI,
       "Expected format to be AV_PIX_FMT_VAAPI, got " +

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -22,6 +22,7 @@ extern "C" {
 #include <libavfilter/buffersrc.h>
 #include <libavutil/hwcontext_vaapi.h>
 #include <libavutil/pixdesc.h>
+#include <libswscale/swscale.h>
 }
 
 namespace facebook::torchcodec {
@@ -74,7 +75,10 @@ bool has_fp64(const StableDevice& device) {
 
 UniqueAVBufferRef getVaapiContext(const StableDevice& device) {
   enum AVHWDeviceType type = av_hwdevice_find_type_by_name("vaapi");
-  TORCH_CHECK(type != AV_HWDEVICE_TYPE_NONE, "Failed to find vaapi device");
+  if (type == AV_HWDEVICE_TYPE_NONE) {
+    LOG(WARNING) << "VAAPI hwdevice type not found in this FFmpeg build.";
+    return UniqueAVBufferRef(nullptr);
+  }
   int deviceIndex = getDeviceIndex(device);
 
   UniqueAVBufferRef hw_device_ctx = g_cached_hw_device_ctxs.get(device);
@@ -94,12 +98,52 @@ UniqueAVBufferRef getVaapiContext(const StableDevice& device) {
   AVBufferRef* ctx = nullptr;
   int err = av_hwdevice_ctx_create(&ctx, type, renderD.c_str(), nullptr, 0);
   if (err < 0) {
-    TORCH_CHECK(
-        false,
-        "Failed to create specified HW device: ",
-        getFFMPEGErrorStringFromErrorCode(err));
+    LOG(WARNING) << "Failed to create VAAPI device context on " << renderD
+                 << ": " << getFFMPEGErrorStringFromErrorCode(err)
+                 << "; all codecs will fall back to CPU.";
+    return UniqueAVBufferRef(nullptr);
   }
   return UniqueAVBufferRef(ctx);
+}
+
+// Resolve the VAAPI render-node path this XPU device should open. Duplicates
+// getVaapiContext's internal logic so we can surface the path for diagnostics
+// even when getVaapiContext returns null.
+std::string resolveRenderD(const StableDevice& device) {
+  std::string renderD = "/dev/dri/renderD128";
+  int deviceIndex = getDeviceIndex(device);
+  sycl::device syclDevice = c10::xpu::get_raw_device(deviceIndex);
+  if (syclDevice.has(sycl::aspect::ext_intel_pci_address)) {
+    auto BDF =
+        syclDevice.get_info<sycl::ext::intel::info::device::pci_address>();
+    renderD = "/dev/dri/by-path/pci-" + BDF + "-render";
+  }
+  return renderD;
+}
+
+// Returns true if FFmpeg was built with VAAPI HW decode support for this
+// codec. Physical device capability is validated lazily at the first decoded
+// frame via the silent-SW-fallback detection in convertAVFrameToFrameOutput.
+// The AVBufferRef argument is intentionally unused; this is a pure FFmpeg
+// metadata check.
+bool deviceSupportsHWDecode(
+    AVBufferRef* /*hw_device_ctx*/,
+    AVCodecID codec_id) {
+  const AVCodec* decoder = avcodec_find_decoder(codec_id);
+  if (!decoder) {
+    return false;
+  }
+  for (int i = 0;; ++i) {
+    const AVCodecHWConfig* cfg = avcodec_get_hw_config(decoder, i);
+    if (!cfg) {
+      break;
+    }
+    if ((cfg->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
+        cfg->device_type == AV_HWDEVICE_TYPE_VAAPI) {
+      return true;
+    }
+  }
+  return false;
 }
 
 torch::stable::Tensor allocateEmptyHWCTensor(
@@ -114,6 +158,62 @@ torch::stable::Tensor allocateEmptyHWCTensor(
       kStableUInt8,
       std::nullopt,
       device);
+}
+
+// Self-contained SW NV12/YUV->RGB24 conversion for the CPU fallback path.
+// Uses libswscale directly rather than delegating to CpuDeviceInterface: the
+// relevant torchcodec symbols (CpuDeviceInterface ctor, createDeviceInterface)
+// are not exported from the installed libtorchcodec_core6.so, so delegation is
+// not linkable against the shipped wheel.
+void convertSWFrameToRGB_sws(
+    AVFrame* avFrame,
+    torch::stable::Tensor& dstRGB_CPU) {
+  const int width = avFrame->width;
+  const int height = avFrame->height;
+  auto srcFormat = static_cast<AVPixelFormat>(avFrame->format);
+
+  SwsContext* sws = sws_getContext(
+      width,
+      height,
+      srcFormat,
+      width,
+      height,
+      AV_PIX_FMT_RGB24,
+      SWS_BILINEAR,
+      nullptr,
+      nullptr,
+      nullptr);
+  TORCH_CHECK(
+      sws != nullptr,
+      "sws_getContext failed for ",
+      av_get_pix_fmt_name(srcFormat),
+      " -> RGB24 at ",
+      width,
+      "x",
+      height);
+
+  uint8_t* dstData[4] = {
+      static_cast<uint8_t*>(dstRGB_CPU.mutable_data_ptr()),
+      nullptr,
+      nullptr,
+      nullptr};
+  int dstLinesize[4] = {width * 3, 0, 0, 0};
+
+  int scaled = sws_scale(
+      sws,
+      avFrame->data,
+      avFrame->linesize,
+      0,
+      height,
+      dstData,
+      dstLinesize);
+  sws_freeContext(sws);
+  TORCH_CHECK(
+      scaled == height,
+      "sws_scale produced ",
+      scaled,
+      " lines, expected ",
+      height);
 }
 
 } // namespace xpu
@@ -141,7 +241,16 @@ XpuDeviceInterface::XpuDeviceInterface(const StableDevice& device)
   // This is a dummy tensor to initialize the xpu context.
   torch::stable::Tensor dummyTensorForXpuInitialization = torch::stable::empty(
       {1}, kStableUInt8, std::nullopt, StableDevice(device));
+
+  renderD_ = xpu::resolveRenderD(device_);
+
+  // Attempt to create the VAAPI device context. If this fails, ctx_ remains
+  // null and registerHardwareDeviceWithCodec will route every codec to CPU.
   ctx_ = xpu::getVaapiContext(device_);
+  if (!ctx_) {
+    VLOG(1) << "No VAAPI device context available on " << renderD_
+            << "; all streams will use SW decode via CPU fallback.";
+  }
 
   if (xpu::use_sycl_color_conversion_kernel()) {
     VLOG(1) << "XpuDeviceInterface initialized with SYCL kernel backend";
@@ -164,7 +273,7 @@ XpuDeviceInterface::~XpuDeviceInterface() {
 void XpuDeviceInterface::initialize(
     const AVStream* avStream,
     [[maybe_unused]] const UniqueDecodingAVFormatContext& avFormatCtx,
-    [[maybe_unused]] const SharedAVCodecContext& codecContext) {
+    const SharedAVCodecContext& codecContext) {
   TORCH_CHECK(avStream != nullptr, "avStream is null");
   codecContext_ = codecContext;
   timeBase_ = avStream->time_base;
@@ -179,8 +288,16 @@ void XpuDeviceInterface::initializeVideo(
 
 void XpuDeviceInterface::registerHardwareDeviceWithCodec(
     AVCodecContext* codecContext) {
-  TORCH_CHECK(ctx_, "FFmpeg HW device has not been initialized");
   TORCH_CHECK(codecContext != nullptr, "codecContext is null");
+  if (!ctx_ ||
+      !xpu::deviceSupportsHWDecode(ctx_.get(), codecContext->codec_id)) {
+    LOG(WARNING) << "No VAAPI HW decode for codec "
+                 << avcodec_get_name(codecContext->codec_id) << " on device "
+                 << renderD_ << "; falling back to CPU for this stream.";
+    hwDecodeActiveForCurrentStream_ = false;
+    return;
+  }
+  hwDecodeActiveForCurrentStream_ = true;
   codecContext->hw_device_ctx = av_buffer_ref(ctx_.get());
 }
 
@@ -315,6 +432,41 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
     UniqueAVFrame& avFrame,
     FrameOutput& frameOutput,
     std::optional<torch::stable::Tensor> preAllocatedOutputTensor) {
+  // Detect silent SW fallback: HW path was requested but FFmpeg produced a SW
+  // frame. This happens on devices without video decode engines (e.g. PVC),
+  // where av_hwdevice_ctx_create succeeds but the hardware has no media
+  // blocks, so FFmpeg silently falls back to software decode on the first
+  // packet.
+  if (hwDecodeActiveForCurrentStream_ && avFrame->format != AV_PIX_FMT_VAAPI) {
+    LOG(WARNING) << "Expected VAAPI frame but got SW format "
+                 << av_get_pix_fmt_name((AVPixelFormat)avFrame->format)
+                 << " on device " << renderD_
+                 << "; device has no HW decode engine for this codec."
+                 << " Switching stream to CPU path.";
+    hwDecodeActiveForCurrentStream_ = false;
+  }
+
+  if (!hwDecodeActiveForCurrentStream_) {
+    // Self-contained SW->RGB conversion via libswscale. We do not delegate to
+    // CpuDeviceInterface because its constructor and the createDeviceInterface
+    // factory are not exported from the installed libtorchcodec_core wheel.
+    auto frameDims = FrameDims(avFrame->height, avFrame->width);
+    torch::stable::Tensor cpuRGB = torch::stable::empty(
+        {frameDims.height, frameDims.width, 3},
+        kStableUInt8,
+        std::nullopt,
+        StableDevice(kStableCPU));
+    xpu::convertSWFrameToRGB_sws(avFrame.get(), cpuRGB);
+
+    if (preAllocatedOutputTensor.has_value()) {
+      torch::stable::copy_(preAllocatedOutputTensor.value(), cpuRGB);
+      frameOutput.data = preAllocatedOutputTensor.value();
+    } else {
+      frameOutput.data = cpuRGB;
+    }
+    return;
+  }
+
   // TODO: consider to copy handling of CPU frame from CUDA
   // TODO: consider to copy NV12 format check from CUDA
   TORCH_CHECK(

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -84,13 +84,9 @@ std::string resolveRenderD(const StableDevice& device) {
   return renderD;
 }
 
-
 UniqueAVBufferRef getVaapiContext(const StableDevice& device) {
   enum AVHWDeviceType type = av_hwdevice_find_type_by_name("vaapi");
-  if (type == AV_HWDEVICE_TYPE_NONE) {
-    VLOG(1) << "VAAPI hwdevice type not found in this FFmpeg build.";
-    return UniqueAVBufferRef(nullptr);
-  }
+  TORCH_CHECK(type != AV_HWDEVICE_TYPE_NONE, "Failed to find vaapi device");
 
   UniqueAVBufferRef hw_device_ctx = g_cached_hw_device_ctxs.get(device);
   if (hw_device_ctx) {
@@ -102,33 +98,12 @@ UniqueAVBufferRef getVaapiContext(const StableDevice& device) {
   AVBufferRef* ctx = nullptr;
   int err = av_hwdevice_ctx_create(&ctx, type, renderD.c_str(), nullptr, 0);
   if (err < 0) {
-    VLOG(1) << "Failed to create VAAPI device context on " << renderD
-            << ": " << getFFMPEGErrorStringFromErrorCode(err)
-            << "; all codecs will fall back to CPU.";
-    return UniqueAVBufferRef(nullptr);
+    TORCH_CHECK(
+        false,
+        "Failed to create specified HW device: ",
+        getFFMPEGErrorStringFromErrorCode(err));
   }
   return UniqueAVBufferRef(ctx);
-}
-
-// Returns true if FFmpeg was built with VAAPI HW decode support for this
-// codec. Physical device capability is validated lazily at the first decoded
-// frame via the silent-SW-fallback detection in convertAVFrameToFrameOutput.
-bool deviceSupportsHWDecode(AVCodecID codec_id) {
-  const AVCodec* decoder = avcodec_find_decoder(codec_id);
-  if (!decoder) {
-    return false;
-  }
-  for (int i = 0;; ++i) {
-    const AVCodecHWConfig* cfg = avcodec_get_hw_config(decoder, i);
-    if (!cfg) {
-      break;
-    }
-    if ((cfg->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
-        cfg->device_type == AV_HWDEVICE_TYPE_VAAPI) {
-      return true;
-    }
-  }
-  return false;
 }
 
 torch::stable::Tensor allocateEmptyHWCTensor(
@@ -200,16 +175,7 @@ XpuDeviceInterface::XpuDeviceInterface(const StableDevice& device)
   // This is a dummy tensor to initialize the xpu context.
   torch::stable::Tensor dummyTensorForXpuInitialization = torch::stable::empty(
       {1}, kStableUInt8, std::nullopt, StableDevice(device));
-
-  renderD_ = xpu::resolveRenderD(device_);
-
-  // Attempt to create the VAAPI device context. If this fails, ctx_ remains
-  // null and registerHardwareDeviceWithCodec will route every codec to CPU.
   ctx_ = xpu::getVaapiContext(device_);
-  if (!ctx_) {
-    VLOG(1) << "No VAAPI device context available on " << renderD_
-            << "; all streams will use SW decode via CPU fallback.";
-  }
 
   if (xpu::use_sycl_color_conversion_kernel()) {
     VLOG(1) << "XpuDeviceInterface initialized with SYCL kernel backend";
@@ -247,16 +213,8 @@ void XpuDeviceInterface::initializeVideo(
 
 void XpuDeviceInterface::registerHardwareDeviceWithCodec(
     AVCodecContext* codecContext) {
+  TORCH_CHECK(ctx_, "FFmpeg HW device has not been initialized");
   TORCH_CHECK(codecContext != nullptr, "codecContext is null");
-  if (!ctx_ ||
-      !xpu::deviceSupportsHWDecode(codecContext->codec_id)) {
-    VLOG(1) << "No VAAPI HW decode for codec "
-            << avcodec_get_name(codecContext->codec_id) << " on device "
-            << renderD_ << "; falling back to CPU for this stream.";
-    hwDecodeActiveForCurrentStream_ = false;
-    return;
-  }
-  hwDecodeActiveForCurrentStream_ = true;
   codecContext->hw_device_ctx = av_buffer_ref(ctx_.get());
 }
 
@@ -386,22 +344,14 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
     UniqueAVFrame& avFrame,
     FrameOutput& frameOutput,
     std::optional<torch::stable::Tensor> preAllocatedOutputTensor) {
-  // Detect silent SW fallback: HW path was requested but FFmpeg produced a SW
-  // frame. This happens on devices without video decode engines (e.g. PVC),
-  // where av_hwdevice_ctx_create succeeds but the hardware has no media
-  // blocks, so FFmpeg silently falls back to software decode on the first
-  // packet.
-  if (hwDecodeActiveForCurrentStream_ && avFrame->format != AV_PIX_FMT_VAAPI) {
-    VLOG(1) << "Expected VAAPI frame but got SW format "
-            << av_get_pix_fmt_name((AVPixelFormat)avFrame->format)
-            << " on device " << renderD_
-            << "; device has no HW decode engine for this codec."
-            << " Switching stream to CPU path.";
-    std::string("[XPU Device Interface] Using CPU fallback.");
-    hwDecodeActiveForCurrentStream_ = false;
-  }
+  if (avFrame->format != AV_PIX_FMT_VAAPI) {
+    // The frame's format is AV_PIX_FMT_VAAPI if and only if its content is on
+    // the GPU. In this branch, the frame is on the CPU. This is what FFmpeg VAAPI
+    // decoder gives us if it wasn't able to decode a frame, for whatever reason.
+    // Typically that happens if the video's decoder isn't supported by VAAPI in
+    // general or on this particular device. In this case we have a frame on the
+    // CPU. We send the frame back to the XPU device when we're done.
 
-  if (!hwDecodeActiveForCurrentStream_) {
     // Self-contained SW->RGB conversion via libswscale. We do not delegate to
     // CpuDeviceInterface because its constructor and the createDeviceInterface
     // factory are not exported from the installed libtorchcodec_core wheel.
@@ -413,6 +363,9 @@ void XpuDeviceInterface::convertAVFrameToFrameOutput(
         StableDevice(kStableCPU));
     xpu::convertSWFrameToRGB_sws(avFrame.get(), cpuRGB);
 
+    // Finally, we need to send the frame back to the GPU. Note that the
+    // pre-allocated tensor is on the GPU, so we can't send that to the CPU
+    // device interface. We copy it over here.
     if (preAllocatedOutputTensor.has_value()) {
       torch::stable::copy_(preAllocatedOutputTensor.value(), cpuRGB);
       frameOutput.data = preAllocatedOutputTensor.value();

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
@@ -43,6 +43,16 @@ class XpuDeviceInterface : public DeviceInterface {
   AVRational timeBase_;
   bool has_fp64_;
 
+  // VAAPI render-node path used for this XPU device (e.g. /dev/dri/renderD128
+  // or a PCI-BDF-indexed path). Captured at construction so it can appear in
+  // diagnostic logs emitted later by the CPU-fallback path.
+  std::string renderD_;
+
+  // Per-stream flag set by registerHardwareDeviceWithCodec(). Stays false if
+  // VAAPI is unavailable, if the codec has no VAAPI decode support, or if the
+  // first decoded frame reveals a silent FFmpeg SW fallback.
+  bool hwDecodeActiveForCurrentStream_ = false;
+
   UniqueAVBufferRef ctx_;
 
   std::unique_ptr<FilterGraph> filterGraph_;

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
@@ -43,16 +43,6 @@ class XpuDeviceInterface : public DeviceInterface {
   AVRational timeBase_;
   bool has_fp64_;
 
-  // VAAPI render-node path used for this XPU device (e.g. /dev/dri/renderD128
-  // or a PCI-BDF-indexed path). Captured at construction so it can appear in
-  // diagnostic logs emitted later by the CPU-fallback path.
-  std::string renderD_;
-
-  // Per-stream flag set by registerHardwareDeviceWithCodec(). Stays false if
-  // VAAPI is unavailable, if the codec has no VAAPI decode support, or if the
-  // first decoded frame reveals a silent FFmpeg SW fallback.
-  bool hwDecodeActiveForCurrentStream_ = false;
-
   UniqueAVBufferRef ctx_;
 
   std::unique_ptr<FilterGraph> filterGraph_;


### PR DESCRIPTION
PR implements CPU fallback handling PVC behavior (no media hardware device) and 10-bit decoding CPU fallback.

Fixes: https://github.com/intel/torchlib-xpu/issues/13
Fixes: https://github.com/intel/torchlib-xpu/issues/16