### PR TITLE
ci: login with docker credentials on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,9 @@ jobs:
     runs-on: ${{matrix.runner}}
     container:
       image: 'ubuntu:24.04'
+      credentials:
+        username: ${{vars.DH_USER}}
+        password: ${{secrets.DH_TOKEN}}
       options: --device /dev/dri:/dev/dri -v /dev/dri/by-path:/dev/dri/by-path
     env:
       WHEELS: torchlib-${{ matrix.python-version }}-wheels


### PR DESCRIPTION
Logging in increases pull limits for docker hub and contributes to better CI stability.