### PR TITLE
ci: update intel repo key before fetching packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: 'Install prerequisites'
       run: |
+        rpm --import https://repositories.intel.com/gpu/intel-graphics.key
         dnf install -y libva-devel
     - name: 'Build the project'
       env:


### PR DESCRIPTION
Key is being updated from time to time so we need to fetch the most recent version on the cached docker build image to make installing packages work.