### PR TITLE
torchcodec-xpu: enable plugin autoloading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,21 +131,6 @@ jobs:
         uv pip install \
           _wheels/${{ env.WHEELS }}-${{ env.PR_OR_SHA }}-${{ env.UNIQUE_ID }}/*.whl \
           --index https://download.pytorch.org/whl/xpu -vv
-    - name: 'Test importing torchcodec-xpu with ffmpeg n6'
-      env:
-        LD_LIBRARY_PATH: '${{ github.workspace }}/_install/ffmpeg-n6.1.4/lib'
-      run: |
-        uv run --no-project python -c "import torchcodec_xpu; print(torchcodec_xpu.__version__)"
-    - name: 'Test importing torchcodec-xpu with ffmpeg n7'
-      env:
-        LD_LIBRARY_PATH: '${{ github.workspace }}/_install/ffmpeg-n7.1.3/lib'
-      run: |
-        uv run --no-project python -c "import torchcodec_xpu; print(torchcodec_xpu.__version__)"
-    - name: 'Test importing torchcodec-xpu with ffmpeg n8'
-      env:
-        LD_LIBRARY_PATH: '${{ github.workspace }}/_install/ffmpeg-n8.0.1/lib'
-      run: |
-        uv run --no-project python -c "import torchcodec_xpu; print(torchcodec_xpu.__version__)"
     - name: 'Upload wheels'
       uses: actions/upload-artifact@v7
       with:

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ At the moment project provides plugins for the following frameworks:
 
 [TorchCodec] is a high-performance Python library designed for media processing (decoding and encoding) using PyTorch* tensors. Intel® XPU plugin for [TorchCodec] enables hardware acceleration for video operations (only decoding at the moment) on Linux. Both [TorchCodec] and Intel® plugin rely on the FFmpeg libraries for their operations which must be pre-installed on the system. Intel® plugin further assumes that FFmpeg is built with the VAAPI support.
 
-To use Intel® XPU plugin for [TorchCodec], load it in the Python script and pass XPU device to initialize [TorchCodec] decoder or encoder:
+[TorchCodec] will automatically load Intel® XPU plugin if it is installed on the system via Python packages entry point mechanism. After importing TorchCodec, pass XPU device to initialize [TorchCodec] decoder or encoder:
 
 ```
 import torchcodec
-import torchcodec_xpu
 
 decoder = torchcodec.decoders.VideoDecoder(
     "input.mp4", device="xpu:0")

--- a/packages/torchcodec-xpu/README.md
+++ b/packages/torchcodec-xpu/README.md
@@ -4,11 +4,10 @@
 
 [TorchCodec] is a high-performance Python library designed for media processing (decoding and encoding) using PyTorch* tensors. Intel® XPU plugin for [TorchCodec] enables hardware acceleration for video operations (only decoding at the moment) on Linux. Both [TorchCodec] and Intel® plugin rely on the FFmpeg libraries for their operations which must be pre-installed on the system. Intel® plugin further assumes that FFmpeg is built with the VAAPI support.
 
-To use Intel® XPU plugin for [TorchCodec], load it in the Python script and pass XPU device to initialize [TorchCodec] decoder or encoder:
+[TorchCodec] will automatically load Intel® XPU plugin if it is installed on the system via Python packages entry point mechanism. After importing TorchCodec, pass XPU device to initialize [TorchCodec] decoder or encoder:
 
 ```
 import torchcodec
-import torchcodec_xpu
 
 decoder = torchcodec.decoders.VideoDecoder(
     "input.mp4", device="xpu:0")

--- a/packages/torchcodec-xpu/patches/0001-Add-XPU-support-to-tests.patch
+++ b/packages/torchcodec-xpu/patches/0001-Add-XPU-support-to-tests.patch
@@ -1,4 +1,4 @@
-From 4c221c043d72cb2bfe80e9c92f2ebf0c2629d731 Mon Sep 17 00:00:00 2001
+From f31ac9b7e2be204db010ab54fd44109fc8f79d0f Mon Sep 17 00:00:00 2001
 From: Edgar Romo Montiel <edgar.romo.montiel@intel.com>
 Date: Tue, 9 Dec 2025 14:36:08 -0800
 Subject: [PATCH] Add XPU support to tests
@@ -7,8 +7,8 @@ Signed-off-by: Edgar Romo Montiel <edgar.romo.montiel@intel.com>
 ---
  test/conftest.py | 19 +++++++++++++++++--
  test/test_ops.py | 14 ++++++++++++++
- test/utils.py    | 19 +++++++++++++++++++
- 3 files changed, 50 insertions(+), 2 deletions(-)
+ test/utils.py    | 17 +++++++++++++++++
+ 3 files changed, 48 insertions(+), 2 deletions(-)
 
 diff --git a/test/conftest.py b/test/conftest.py
 index 0588f83b..48d87001 100644
@@ -73,10 +73,10 @@ index 0588f83b..48d87001 100644
 +    if torch.xpu.is_available():
 +        torch.xpu.set_rng_state(xpu_rng_state)
 diff --git a/test/test_ops.py b/test/test_ops.py
-index 4c68b658..df277f31 100644
+index 09c9c491..ba33bd0b 100644
 --- a/test/test_ops.py
 +++ b/test/test_ops.py
-@@ -49,6 +49,7 @@ from .utils import (
+@@ -48,6 +48,7 @@ from .utils import (
      NASA_AUDIO_MP3,
      NASA_VIDEO,
      needs_cuda,
@@ -84,7 +84,7 @@ index 4c68b658..df277f31 100644
      needs_ffmpeg_cli,
      SINE_MONO_S32,
      SINE_MONO_S32_44100,
-@@ -652,6 +653,19 @@ class TestVideoDecoderOps:
+@@ -651,6 +652,19 @@ class TestVideoDecoderOps:
              duration, torch.tensor(0.0334).double(), atol=0, rtol=1e-3
          )
  
@@ -105,19 +105,10 @@ index 4c68b658..df277f31 100644
  class TestAudioDecoderOps:
      @pytest.mark.parametrize(
 diff --git a/test/utils.py b/test/utils.py
-index 773fe966..e8280c96 100644
+index 5a72a804..ca8ee597 100644
 --- a/test/utils.py
 +++ b/test/utils.py
-@@ -17,6 +17,8 @@ from torchcodec._core import get_ffmpeg_library_versions
- from torchcodec.decoders import set_cuda_backend, VideoDecoder
- from torchcodec.decoders._video_decoder import _read_custom_frame_mappings
- 
-+import torchcodec_xpu
-+
- IS_WINDOWS = sys.platform in ("win32", "cygwin")
- IN_GITHUB_CI = bool(os.getenv("GITHUB_ACTIONS"))
- 
-@@ -47,6 +49,13 @@ def needs_cuda(test_item):
+@@ -47,6 +47,13 @@ def needs_cuda(test_item):
      return pytest.mark.needs_cuda(test_item)
  
  
@@ -131,7 +122,7 @@ index 773fe966..e8280c96 100644
  # Decorator for skipping ffmpeg tests when ffmpeg cli isn't available. The tests are
  # effectively marked to be skipped in pytest_collection_modifyitems() of
  # conftest.py
-@@ -69,6 +78,7 @@ def all_supported_devices():
+@@ -69,6 +76,7 @@ def all_supported_devices():
          "cpu",
          pytest.param("cuda", marks=pytest.mark.needs_cuda),
          pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
@@ -139,7 +130,7 @@ index 773fe966..e8280c96 100644
      )
  
  
-@@ -164,6 +174,15 @@ def assert_frames_equal(*args, **kwargs):
+@@ -164,6 +172,15 @@ def assert_frames_equal(*args, **kwargs):
                  )
              else:
                  torch.testing.assert_close(*args, **kwargs, atol=atol, rtol=0)

--- a/packages/torchcodec-xpu/pyproject.toml
+++ b/packages/torchcodec-xpu/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
 [project.urls]
 GitHub = "https://github.com/intel/torchlib-xpu"
 
+[project.entry-points.'torchcodec.backends']
+device_backend = 'torchcodec_xpu:load_torchcodec_xpu_shared_library'
+
 [project.optional-dependencies]
 test = [
     "numpy",

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/__init__.py
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/__init__.py
@@ -6,9 +6,6 @@ import ctypes
 import importlib
 import traceback
 
-import torch
-import torchcodec
-
 try:
     # Note that version.py is generated during install
     from ._version import __version__
@@ -23,6 +20,12 @@ def _get_extension_path(lib_name: str) -> str:
     return spec.origin
 
 def load_torchcodec_xpu_shared_library():
+    import torch
+
+    # Loading torchcodec at globabl scope will create a circular
+    # dependency for plugin loading and must be avoided.
+    import torchcodec
+
     exceptions = []
     ffmpeg_major_version = torchcodec.ffmpeg_major_version
     xpu_library_name = f"torchcodec_xpu.xpu_ops{ffmpeg_major_version}"
@@ -52,6 +55,3 @@ def load_torchcodec_xpu_shared_library():
         """
         f"{traceback_info}"
     )
-
-load_torchcodec_xpu_shared_library()
-


### PR DESCRIPTION
This commit eliminates the need to `import torchcodec_xpu` and relies on the Python packages entry-point load mechanism. Plugin just needs to be installed on the system. On TorchCodec level plugin loading is enabled by default, but can be disabled with `TORCHCODEC_DEVICE_BACKEND_AUTOLOAD=0`.

Note that `import torchcodec_xpu` is still possible (to get version), but it won't load `torchcodec` as it did before.

Fixes: https://github.com/intel/torchlib-xpu/issues/97
Requires: https://github.com/meta-pytorch/torchcodec/pull/1151