### PR TITLE
Switch to pytorch ~=v2.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     env:
       WHEELS: torchlib-${{ matrix.python-version }}-wheels
     container:
-      image: 'pytorch/manylinux2_28-builder:xpu-v2.12.0-rc1'
+      image: 'pytorch/manylinux2_28-builder:xpu-v2.13.0-rc1'
     steps:
     - name: 'Checkout'
       uses: actions/checkout@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,7 @@ Use the following compatibility table when self-building the project and its dep
 
 | PyTorch | Torchvision | oneAPI         |
 | ------- | ----------- | -------------- |
+| 2.13    | 0.28        | [2026.0][2-13] |
 | 2.12    | 0.27        | [2025.3][2-12] |
 | 2.11    | 0.26        | [2025.3][2-11] |
 | 2.10    | 0.25        | [2025.3][2-10] |
@@ -108,6 +109,7 @@ Use the following compatibility table when self-building the project and its dep
 
 [TorchCodec]: https://github.com/meta-pytorch/torchcodec
 
+[2-13]: https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-13.html
 [2-12]: https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-12.html
 [2-11]: https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-11.html
 [2-10]: https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-10.html

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install torchlib-xpu \
 
 * Install [uv]
 
-* Install oneAPI [2025.3]
+* Install oneAPI [2026.0]
 
 * Install FFmpeg development environment with enabled VAAPI hardware acceleration. For example:
 
@@ -88,4 +88,4 @@ uv venv && uv pip install -e . \
 [TorchCodec]: https://github.com/meta-pytorch/torchcodec
 [uv]: https://github.com/astral-sh/uv
 
-[2025.3]: https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-10.html
+[2026.0]: https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-13.html

--- a/packages/fbgemm-xpu/README.md
+++ b/packages/fbgemm-xpu/README.md
@@ -25,7 +25,7 @@ For now, build from source:
 
 * Install [uv]
 
-* Install Intel oneAPI (DPC++ compiler `icpx`), version 2025.3 or newer
+* Install Intel oneAPI (DPC++ compiler `icpx`), version 2026.0
 
 * Clone the repository:
 
@@ -71,4 +71,3 @@ Known limitations will be documented as new FBGEMM operators are integrated into
 [FBGEMM]: https://github.com/pytorch/FBGEMM
 [uv]: https://github.com/astral-sh/uv
 [PVC]: https://www.intel.com/content/www/us/en/ark/products/series/232874/intel-data-center-gpu-max-series.html
-

--- a/packages/fbgemm-xpu/pyproject.toml
+++ b/packages/fbgemm-xpu/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "numpy~=2.0",
     "pybind11",
     "scikit-build-core>=0.10",
-    "torch~=2.12.0",
+    "torch~=2.13.0",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -20,9 +20,9 @@ authors = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "fbgemm-gpu-cpu==1.7.0",
+    "fbgemm-gpu-cpu==1.8.0",
     "numpy~=2.0",
-    "torch~=2.12.0",
+    "torch~=2.13.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/torchcodec-xpu/pyproject.toml
+++ b/packages/torchcodec-xpu/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "pybind11",
     "scikit-build-core>=0.10",
-    "torch~=2.12.0",  # WA: must be specified in root project with build-constraint-dependencies
+    "torch~=2.13.0",  # WA: must be specified in root project with build-constraint-dependencies
     "torchcodec~=0.15.0"
 ]
 build-backend = "scikit_build_core.build"
@@ -18,7 +18,7 @@ authors = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "torch~=2.12.0",
+    "torch~=2.13.0",
     "torchcodec~=0.15.0"
 ]
 


### PR DESCRIPTION
Note that pytorch `v2.13.x` comes with the updated dependency on oneAPI DLE to version `2026.0`.

CC: @aagalleg