### PR TITLE
Add video encoding support with SYCL RGB→NV12 kernel and CPU fallback

### DIFF
--- a/packages/torchcodec-xpu/patches/0002-Add-XPU-support-to-video-encoder-tests.patch
+++ b/packages/torchcodec-xpu/patches/0002-Add-XPU-support-to-video-encoder-tests.patch
@@ -28,20 +28,13 @@ marker and imports torchcodec_xpu in test/utils.py).
 
 Signed-off-by: Edgar Romo Montiel <edgar.romo.montiel@intel.com>
 ---
- test/test_encoders.py | 82 ++++++++++++++++++++++++++++++++++++---------------
- 1 file changed, 58 insertions(+), 24 deletions(-)
+ test/test_encoders.py | 79 +++++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 55 insertions(+), 24 deletions(-)
 
 diff --git a/test/test_encoders.py b/test/test_encoders.py
 --- a/test/test_encoders.py
 +++ b/test/test_encoders.py
-@@ -1,3 +1,6 @@
-+import torchcodec
-+import torchcodec_xpu
-+
- import io
- import os
- import platform
-@@ -25,6 +28,7 @@ from .utils import (
+@@ -25,6 +25,7 @@ from .utils import (
      NASA_AUDIO_MP3_44100,
      NASA_VIDEO,
      needs_cuda,
@@ -49,7 +42,7 @@ diff --git a/test/test_encoders.py b/test/test_encoders.py
      needs_ffmpeg_cli,
      psnr,
      SINE_MONO_S32,
-@@ -194,11 +198,23 @@ class TestEncoder:
+@@ -194,11 +195,23 @@ class TestEncoder:
          pytest.param(
              "cuda",
              marks=[
@@ -73,7 +66,7 @@ diff --git a/test/test_encoders.py b/test/test_encoders.py
  
      @staticmethod
      def _create_encoder(method, tmp_path, format):
-@@ -254,10 +270,12 @@ class TestEncoder:
+@@ -254,10 +267,12 @@ class TestEncoder:
      def test_add_video_and_encode_frames(self, tmp_path, format, method, device):
 +        if device == "xpu":
 +            device = f"xpu:{torch.xpu.current_device()}"
@@ -87,7 +80,7 @@ diff --git a/test/test_encoders.py b/test/test_encoders.py
  
          enc, encoder_output, open_kwargs = self._create_encoder(
              method, tmp_path, format
-@@ -314,10 +332,12 @@ class TestEncoder:
+@@ -314,10 +329,12 @@ class TestEncoder:
      def test_fragmented_mp4(self, format, tmp_path, method, device):
 +        if device == "xpu":
 +            device = f"xpu:{torch.xpu.current_device()}"
@@ -101,7 +94,7 @@ diff --git a/test/test_encoders.py b/test/test_encoders.py
  
          enc, encoder_output, open_kwargs = self._create_encoder(
              method, tmp_path, format
-@@ -333,9 +353,13 @@ class TestEncoder:
+@@ -333,9 +350,13 @@ class TestEncoder:
              "flush_packets": "1",
              "threads": "1",
          }
@@ -117,7 +110,7 @@ diff --git a/test/test_encoders.py b/test/test_encoders.py
          else:
              extra_options["tune"] = "zerolatency"
              pixel_format, crf = "yuv444p", 0
-@@ -374,7 +398,9 @@ class TestEncoder:
+@@ -374,7 +395,9 @@ class TestEncoder:
  
      @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
      @pytest.mark.parametrize("device", cpu_and_oss_cuda)
@@ -127,7 +120,7 @@ diff --git a/test/test_encoders.py b/test/test_encoders.py
          enc, _, open_kwargs = self._create_encoder(method, tmp_path, "mp4")
          video = enc.add_video(height=256, width=256, frame_rate=30.0, device=device)
          self._open_encoder(enc, open_kwargs)
-@@ -395,41 +421,50 @@ class TestEncoder:
+@@ -395,41 +418,50 @@ class TestEncoder:
          with pytest.raises(RuntimeError, match="same dimensions"):
              video.add_frames(frames_512)
  

--- a/packages/torchcodec-xpu/patches/0002-Add-XPU-support-to-video-encoder-tests.patch
+++ b/packages/torchcodec-xpu/patches/0002-Add-XPU-support-to-video-encoder-tests.patch
@@ -1,0 +1,196 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Edgar Romo Montiel <edgar.romo.montiel@intel.com>
+Date: Wed, 10 Jul 2026 12:00:00 -0800
+Subject: [PATCH] Add XPU support to video encoder tests
+
+Extends TorchCodec's video-encoder tests to also exercise the XPU device
+via the torchcodec_xpu plugin. Audio-encoder tests are intentionally left
+untouched. The two previously CUDA-only tests are generalized to run
+against any accelerator device (cuda + xpu) via a new `accel_devices`
+parametrization tuple.
+
+Because torchcodec's Encoder.cpp performs an exact device-equality check
+(index included), and torchcodec_xpu does not currently normalize
+`xpu:-1` -> `xpu:<current>`, each XPU-enabled test explicitly promotes
+`device="xpu"` to `f"xpu:{torch.xpu.current_device()}"` so the encoder
+and the input frames end up on the same fully-qualified device.
+
+Additionally, `test_write_frames_different_devices_errors` opens an XPU
+encoder that would otherwise be destroyed without ever receiving a frame.
+libavcodec's h264_vaapi encoder segfaults on the flush signal
+(`avcodec_send_frame(codec, NULL)`) when no frame was previously encoded,
+so on XPU we prime the encoder with one valid frame and close it
+explicitly before the test function returns. NVENC tolerates the empty
+flush; VAAPI does not.
+
+Depends on 0001-Add-XPU-support-to-tests.patch (defines the needs_xpu
+marker and imports torchcodec_xpu in test/utils.py).
+
+Signed-off-by: Edgar Romo Montiel <edgar.romo.montiel@intel.com>
+---
+ test/test_encoders.py | 82 ++++++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 58 insertions(+), 24 deletions(-)
+
+diff --git a/test/test_encoders.py b/test/test_encoders.py
+--- a/test/test_encoders.py
++++ b/test/test_encoders.py
+@@ -1,3 +1,6 @@
++import torchcodec
++import torchcodec_xpu
++
+ import io
+ import os
+ import platform
+@@ -25,6 +28,7 @@ from .utils import (
+     NASA_AUDIO_MP3_44100,
+     NASA_VIDEO,
+     needs_cuda,
++    needs_xpu,
+     needs_ffmpeg_cli,
+     psnr,
+     SINE_MONO_S32,
+@@ -194,11 +198,23 @@ class TestEncoder:
+         pytest.param(
+             "cuda",
+             marks=[
+                 pytest.mark.needs_cuda,
+                 pytest.mark.skipif(in_fbcode(), reason="NVENC not available in fbcode"),
+             ],
+         ),
++        pytest.param("xpu", marks=pytest.mark.needs_xpu),
++    )
++
++    accel_devices = (
++        pytest.param(
++            "cuda",
++            marks=[
++                pytest.mark.needs_cuda,
++                pytest.mark.skipif(in_fbcode(), reason="NVENC not available in fbcode"),
++            ],
++        ),
++        pytest.param("xpu", marks=pytest.mark.needs_xpu),
+     )
+ 
+     @staticmethod
+     def _create_encoder(method, tmp_path, format):
+@@ -254,10 +270,12 @@ class TestEncoder:
+     def test_add_video_and_encode_frames(self, tmp_path, format, method, device):
++        if device == "xpu":
++            device = f"xpu:{torch.xpu.current_device()}"
+         source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
+         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
+             device
+         )
+         frame_rate = source_decoder.metadata.average_fps
+-        percentage, atol = (96, 2) if device == "cuda" else (99, 2)
++        percentage, atol = (96, 2) if device.startswith(("cuda", "xpu")) else (99, 2)
+ 
+         enc, encoder_output, open_kwargs = self._create_encoder(
+             method, tmp_path, format
+@@ -314,10 +332,12 @@ class TestEncoder:
+     def test_fragmented_mp4(self, format, tmp_path, method, device):
++        if device == "xpu":
++            device = f"xpu:{torch.xpu.current_device()}"
+         source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
+         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
+             device
+         )
+         frame_rate = source_decoder.metadata.average_fps
+-        percentage, atol = (96, 2) if device == "cuda" else (99, 2)
++        percentage, atol = (96, 2) if device.startswith(("cuda", "xpu")) else (99, 2)
+ 
+         enc, encoder_output, open_kwargs = self._create_encoder(
+             method, tmp_path, format
+@@ -333,9 +353,13 @@ class TestEncoder:
+             "flush_packets": "1",
+             "threads": "1",
+         }
+-        if device == "cuda":
+-            extra_options.update({"qp": "1", "delay": "0"})
++        if device.startswith(("cuda", "xpu")):
++            extra_options["qp"] = "1"
++            if device.startswith("cuda"):
++                extra_options["delay"] = "0"
++            else:
++                extra_options["async_depth"] = "1"
+             pixel_format, crf = None, None
+         else:
+             extra_options["tune"] = "zerolatency"
+             pixel_format, crf = "yuv444p", 0
+@@ -374,7 +398,9 @@ class TestEncoder:
+ 
+     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+     @pytest.mark.parametrize("device", cpu_and_oss_cuda)
+     def test_write_frames_mismatched_dimensions_errors(self, tmp_path, method, device):
++        if device == "xpu":
++            device = f"xpu:{torch.xpu.current_device()}"
+         enc, _, open_kwargs = self._create_encoder(method, tmp_path, "mp4")
+         video = enc.add_video(height=256, width=256, frame_rate=30.0, device=device)
+         self._open_encoder(enc, open_kwargs)
+@@ -395,41 +421,50 @@ class TestEncoder:
+         with pytest.raises(RuntimeError, match="same dimensions"):
+             video.add_frames(frames_512)
+ 
+-    @needs_cuda
+     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+-    def test_write_frames_different_devices_errors(self, tmp_path, method):
++    @pytest.mark.parametrize("device", accel_devices)
++    def test_write_frames_different_devices_errors(self, tmp_path, method, device):
++        if device == "xpu":
++            device = f"xpu:{torch.xpu.current_device()}"
+         cpu_frames = torch.randint(0, 256, (2, 3, 256, 256), dtype=torch.uint8)
+-        cuda_frames = cpu_frames.to("cuda")
++        accel_frames = cpu_frames.to(device)
+ 
+-        # CPU stream, write CUDA frames
++        # CPU stream, write accelerator frames
+         enc, _, open_kwargs = self._create_encoder(method, tmp_path, "mp4")
+         video = enc.add_video(height=256, width=256, frame_rate=30.0)
+         self._open_encoder(enc, open_kwargs)
+         video.add_frames(cpu_frames)
+         with pytest.raises(RuntimeError, match="same device"):
+-            video.add_frames(cuda_frames)
++            video.add_frames(accel_frames)
+         enc.close()
+ 
+-        # CUDA stream, write CPU frames
+-        cuda_dir = tmp_path / "cuda"
+-        cuda_dir.mkdir()
+-        enc, _, open_kwargs = self._create_encoder(method, cuda_dir, "mp4")
+-        video = enc.add_video(height=256, width=256, frame_rate=30.0, device="cuda")
++        # Accelerator stream, write CPU frames
++        accel_dir = tmp_path / device.replace(":", "_")
++        accel_dir.mkdir()
++        enc, _, open_kwargs = self._create_encoder(method, accel_dir, "mp4")
++        video = enc.add_video(height=256, width=256, frame_rate=30.0, device=device)
+         self._open_encoder(enc, open_kwargs)
+         with pytest.raises(RuntimeError, match="same device"):
+             video.add_frames(cpu_frames)
++        # Prime the accelerator encoder with one valid frame and close it
++        # explicitly. Without this, VAAPI's flush path (invoked from
++        # ~MultiStreamEncoder -> close -> flush_buffers -> avcodec_send_frame)
++        # segfaults inside libavcodec when asked to flush an h264_vaapi encoder
++        # that never received a single frame.
++        video.add_frames(cpu_frames.to(device))
++        enc.close()
+ 
+-    @needs_cuda
+     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+-    def test_device_None_respects_default_device(self, tmp_path, method):
++    @pytest.mark.parametrize("device", accel_devices)
++    def test_device_None_respects_default_device(self, tmp_path, method, device):
+         source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
+         source_frames = source_decoder.get_frames_in_range(start=0, stop=5).data.to(
+-            "cuda"
++            device
+         )
+         frame_rate = source_decoder.metadata.average_fps
+ 
+         enc, encoder_output, open_kwargs = self._create_encoder(method, tmp_path, "mp4")
+-        with torch.device("cuda:0"):
++        with torch.device(f"{device}:0"):
+             video = enc.add_video(
+                 height=source_frames.shape[2],
+                 width=source_frames.shape[3],
+-- 
+2.48.1

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/ColorConversionKernel.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/ColorConversionKernel.cpp
@@ -9,6 +9,9 @@ namespace facebook::torchcodec {
 
 using float3x3 = std::array<sycl::float3, 3>;
 
+// ============================================================
+// Decoding matrices: YCbCr -> RGB  (used by NV12toRGBKernel)
+// ============================================================
 struct rgb_matrix {
   static constexpr float3x3 BT709 = {
     sycl::float3{ 1.0, 0.0, 1.5748 },
@@ -20,6 +23,26 @@ struct rgb_matrix {
     sycl::float3{ 1.0, 0.0, 1.402 },
     sycl::float3{ 1.0, -0.344136, -0.714136 },
     sycl::float3{ 1.0, 1.772, 0.0}
+  };
+};
+
+// ============================================================
+// Encoding matrices: RGB -> YCbCr  (used by RGB24toNV12Kernel)
+// Inverse of rgb_matrix above.
+// Row 0: Y  coefficients
+// Row 1: Cb coefficients
+// Row 2: Cr coefficients
+// ============================================================
+struct yuv_matrix {
+  static constexpr float3x3 BT709 = {
+    sycl::float3{  0.212600f,   0.715200f,   0.072200f  },  // Y
+    sycl::float3{ -0.114572f,  -0.385428f,   0.5f       },  // Cb
+    sycl::float3{  0.5f,       -0.454153f,  -0.045847f  }   // Cr
+  };
+  static constexpr float3x3 BT601 = {
+    sycl::float3{  0.299f,     0.587f,     0.114f   },  // Y
+    sycl::float3{ -0.168736f, -0.331264f,  0.5f     },  // Cb
+    sycl::float3{  0.5f,      -0.418688f, -0.081312f}   // Cr
   };
 };
 
@@ -166,6 +189,13 @@ const float3x3 getColorConversionMatrix(enum AVColorSpace colorspace) {
   return rgb_matrix::BT601;
 }
 
+const float3x3 getYUVConversionMatrix(enum AVColorSpace colorspace) {
+  if (colorspace == AVCOL_SPC_BT709) {
+    return yuv_matrix::BT709;
+  }
+  return yuv_matrix::BT601;
+}
+
 void convertNV12ToRGB(
     sycl::queue& queue,
     const uint8_t* y_plane,
@@ -199,6 +229,119 @@ void registerColorConversionKernel() {
   // We use volatile to prevent optimization.
   volatile size_t s = sizeof(NV12toRGBKernel);
   (void)s;
+}
+
+// ============================================================
+// Encoding kernel: NCHW RGB tensor -> NV12 VAAPI surface
+// ============================================================
+struct RGB24toNV12Kernel {
+  const uint8_t* rgb_nchw;  // CHW uint8 device pointer (R, G, B planes)
+  int64_t ch_stride;        // stride between channel planes
+  int64_t row_stride;       // stride between rows within a plane
+  int64_t pixel_stride;     // stride between adjacent pixels (1 for NCHW, 3 for HWC-permuted)
+  uint8_t* y_plane;
+  uint8_t* uv_plane;
+  int width;
+  int height;
+  int y_pitch;              // surface Y-plane row pitch in bytes
+  int uv_pitch;             // surface UV-plane row pitch in bytes
+  bool is_tiled;            // true → Tile-Y; false → linear
+  bool fullrange;
+  float3x3 yuv_mat;
+
+  RGB24toNV12Kernel(
+      const uint8_t* rgb_nchw_,
+      int64_t ch_stride_,
+      int64_t row_stride_,
+      int64_t pixel_stride_,
+      uint8_t* y_plane_,
+      uint8_t* uv_plane_,
+      int width_,
+      int height_,
+      int y_pitch_,
+      int uv_pitch_,
+      bool is_tiled_,
+      bool fullrange_,
+      const float3x3& yuv_mat_)
+    : rgb_nchw(rgb_nchw_),
+      ch_stride(ch_stride_),
+      row_stride(row_stride_),
+      pixel_stride(pixel_stride_),
+      y_plane(y_plane_),
+      uv_plane(uv_plane_),
+      width(width_),
+      height(height_),
+      y_pitch(y_pitch_),
+      uv_pitch(uv_pitch_),
+      is_tiled(is_tiled_),
+      fullrange(fullrange_),
+      yuv_mat(yuv_mat_)
+  {}
+
+  void operator()(sycl::id<2> idx) const {
+    int x = idx[1];
+    int y = idx[0];
+
+    if (x >= width || y >= height) {
+      return;
+    }
+
+    // Read RGB from NCHW tensor.
+    float r = rgb_nchw[0 * ch_stride + y * row_stride + x * pixel_stride] / 255.0f;
+    float g = rgb_nchw[1 * ch_stride + y * row_stride + x * pixel_stride] / 255.0f;
+    float b = rgb_nchw[2 * ch_stride + y * row_stride + x * pixel_stride] / 255.0f;
+    sycl::float3 src{r, g, b};
+
+    // Luma Y — write to Tile-Y or linear destination
+    float Y_norm = sycl::dot(src, yuv_mat[0]);
+    float Y = fullrange ? Y_norm * 255.0f : 16.0f + Y_norm * 219.0f;
+    size_t y_dst = is_tiled ? get_tile_offset(x, y, y_pitch)
+                            : (size_t)y * y_pitch + x;
+    y_plane[y_dst] = (uint8_t)std::clamp(Y, 0.0f, 255.0f);
+
+    // Chroma UV: one pair per 2x2 block (NV12 4:2:0 subsampling).
+    if ((x % 2 == 0) && (y % 2 == 0)) {
+      float Cb_norm = sycl::dot(src, yuv_mat[1]);
+      float Cr_norm = sycl::dot(src, yuv_mat[2]);
+      float U = fullrange ? Cb_norm * 255.0f + 128.0f : 128.0f + Cb_norm * 224.0f;
+      float V = fullrange ? Cr_norm * 255.0f + 128.0f : 128.0f + Cr_norm * 224.0f;
+      size_t u_dst = is_tiled ? get_tile_offset(x,     y / 2, uv_pitch)
+                              : (size_t)(y / 2) * uv_pitch + x;
+      size_t v_dst = is_tiled ? get_tile_offset(x + 1, y / 2, uv_pitch)
+                              : (size_t)(y / 2) * uv_pitch + x + 1;
+      uv_plane[u_dst] = (uint8_t)std::clamp(U, 0.0f, 255.0f);
+      uv_plane[v_dst] = (uint8_t)std::clamp(V, 0.0f, 255.0f);
+    }
+  }
+};
+
+void convertRGBToNV12(
+    sycl::queue& queue,
+    const uint8_t* rgb_nchw,
+    int64_t ch_stride,
+    int64_t row_stride,
+    int64_t pixel_stride,
+    uint8_t* dst_y,
+    uint8_t* dst_uv,
+    int width,
+    int height,
+    int y_pitch,
+    int uv_pitch,
+    bool is_tiled,
+    enum AVColorRange color_range,
+    enum AVColorSpace colorspace) {
+  bool fullrange = (color_range == AVCOL_RANGE_JPEG);
+  queue.submit([&](sycl::handler& cgh) {
+    RGB24toNV12Kernel kernel(
+        rgb_nchw, ch_stride, row_stride, pixel_stride,
+        dst_y, dst_uv,
+        width, height,
+        y_pitch, uv_pitch,
+        is_tiled,
+        fullrange, getYUVConversionMatrix(colorspace));
+    cgh.parallel_for(sycl::range<2>(height, width), kernel);
+  });
+  queue.wait();
 }
 
 } // namespace facebook::torchcodec

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/ColorConversionKernel.h
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/ColorConversionKernel.h
@@ -24,6 +24,24 @@ void convertNV12ToRGB(
     enum AVColorRange color_range,
     enum AVColorSpace colorspace);
 
+// Encoding: NCHW uint8 RGB tensor (on XPU) -> NV12 VAAPI surface.
+// is_tiled: true for Intel Tile-Y surfaces (drm_format_modifier != 0), false for linear.
+void convertRGBToNV12(
+    sycl::queue& queue,
+    const uint8_t* rgb_nchw,
+    int64_t ch_stride,
+    int64_t row_stride,
+    int64_t pixel_stride,
+    uint8_t* dst_y,
+    uint8_t* dst_uv,
+    int width,
+    int height,
+    int y_pitch,
+    int uv_pitch,
+    bool is_tiled,
+    enum AVColorRange color_range,
+    enum AVColorSpace colorspace);
+
 // Anchor function to force kernel registration
 void registerColorConversionKernel();
 

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -163,27 +163,6 @@ UniqueAVFrame allocNV12Frame(
   return vaFrame;
 }
 
-// Drains the global VAAPI hwdevice cache. Must be called from Python at
-// interpreter shutdown (via atexit) so that av_buffer_unref() -> vaTerminate()
-// runs while the SYCL / Level Zero / UR runtimes are still alive. Letting the
-// C++ static destructor of g_cached_hw_device_ctxs run at process exit gives
-// undefined ordering vs torch's XPU teardown and typically segfaults inside
-// libva / iHD_drv_video.so on Intel Arc / Battlemage.
-void drain_cached_hw_device_ctxs() noexcept {
-  for (int i = 0; i < MAX_XPU_GPUS; ++i) {
-    try {
-      StableDevice device(kStableXPU, i);
-      // Each pop returns a unique_ptr; when it goes out of scope at the end
-      // of the loop iteration, its custom deleter calls av_buffer_unref().
-      while (auto ctx = g_cached_hw_device_ctxs.get(device)) {
-        (void)ctx;
-      }
-    } catch (...) {
-      // Called from atexit; must never throw across the C ABI boundary.
-    }
-  }
-}
-
 } // namespace xpu
 
 int get_device_index(const StableDevice& device) {
@@ -958,11 +937,3 @@ UniqueAVFrame XpuDeviceInterface::convert_tensor_to_av_frame_for_encoding_cpu(
 }
 
 } // namespace facebook::torchcodec
-
-// C-ABI shutdown entry point. Discovered from Python via ctypes and registered
-// with atexit so it runs BEFORE torch's own XPU teardown handlers. See
-// facebook::torchcodec::xpu::drain_cached_hw_device_ctxs() for details.
-extern "C" __attribute__((visibility("default")))
-void torchcodec_xpu_shutdown() {
-  facebook::torchcodec::xpu::drain_cached_hw_device_ctxs();
-}

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -609,7 +609,7 @@ std::optional<const AVCodec*> XpuDeviceInterface::find_codec(
 
   // Encoder-only fallback: if no VAAPI encoder exists for codecId
   // substitute a HW-capable alternative 
-  if (!is_decoder) {
+   if (!is_decoder) {
     static constexpr AVCodecID kHwEncoderFallbacks[] = {
         AV_CODEC_ID_H264,
         AV_CODEC_ID_HEVC,
@@ -675,7 +675,7 @@ void XpuDeviceInterface::setup_hardware_frame_context_for_encoding(
   hwFramesCtx->width     = codec_context->width;
   hwFramesCtx->height    = codec_context->height;
 
-  // XPU quality is matterially better when using BT.709 color space and full range
+  // XPU quality is materially better when using BT.709 color space and full range
   // (JPEG) for encoding.
   if (codec_context->color_range == AVCOL_RANGE_UNSPECIFIED) {
       codec_context->color_range = AVCOL_RANGE_JPEG;
@@ -701,8 +701,8 @@ void XpuDeviceInterface::setup_hardware_frame_context_for_encoding(
                  AV_OPT_SEARCH_CHILDREN);
   }
 
-  // Disable B-frames (mirrors CUDA/NVENC delay=0) to avoid reorder issues
-  // with fragmented containers; callers can restore via extra_options={"bf":"2"}.
+  // Disable B-frames (mirrors CUDA/NVENC delay=0) to avoid frames reordering.
+  // Callers can restore via extra_options={"bf": "2"}.
   codec_context->max_b_frames = 0;
 
   int ret = av_hwframe_ctx_init(hwFramesCtxRef);
@@ -725,8 +725,21 @@ UniqueAVFrame XpuDeviceInterface::convert_tensor_to_av_frame_for_encoding(
     AVCodecContext* codec_context) {
   TORCH_CHECK(
       tensor.dim() == 3 && tensor.sizes()[0] == 3,
-      "Expected CHW tensor with 3 channels (RGB), got shape: ",
-      tensor.sizes()[0], "x", tensor.sizes()[1], "x", tensor.sizes()[2]);
+      "Expected 3D RGB tensor (CHW format), got ",
+      tensor.dim(),
+      "D tensor");
+  TORCH_CHECK(
+      tensor.device().type() == kStableXPU,
+      "Expected tensor on XPU device, got: ",
+      device_type_name(tensor.device().type()));
+  const int width = static_cast<int>(tensor.sizes()[2]);
+  const int height = static_cast<int>(tensor.sizes()[1]);
+  TORCH_CHECK(
+      (width % 2) == 0 && (height % 2) == 0,
+      "NV12 encoding requires even width/height, got ",
+      width,
+      "x",
+      height);
   TORCH_CHECK(codec_context != nullptr, "codec_context is null");
   TORCH_CHECK(
       codec_context->hw_frames_ctx != nullptr,
@@ -816,10 +829,14 @@ UniqueAVFrame XpuDeviceInterface::convert_tensor_to_av_frame_for_encoding_sycl(
   void* usm_ptr = nullptr;
   ze_result_t res = zeMemAllocDevice(
       zeCtx, &alloc_desc, desc.objects[0].size, 0, zeDevice, &usm_ptr);
-  TORCH_CHECK(
-      res == ZE_RESULT_SUCCESS,
-      "zeMemAllocDevice failed importing encode surface fd=",
-      desc.objects[0].fd);
+
+  if (res != ZE_RESULT_SUCCESS) {
+    close(desc.objects[0].fd);
+    TORCH_CHECK(
+        false,
+        "zeMemAllocDevice failed importing encode surface fd=",
+        desc.objects[0].fd);
+   }
 
   // Extract Y and UV plane pointers and pitches for both layouts
   uint8_t* y_ptr;
@@ -914,7 +931,7 @@ UniqueAVFrame XpuDeviceInterface::convert_tensor_to_av_frame_for_encoding_cpu(
       vaFrame->width, vaFrame->height, AV_PIX_FMT_NV12,
       SWS_BILINEAR, nullptr, nullptr, nullptr);
   TORCH_CHECK(swsCtx != nullptr, "sws_getContext(GBRP->NV12) failed");
-  sws_scale(
+  int sws_ret = sws_scale(
       swsCtx,
       gbrpFrame->data,
       gbrpFrame->linesize,
@@ -923,6 +940,14 @@ UniqueAVFrame XpuDeviceInterface::convert_tensor_to_av_frame_for_encoding_cpu(
       cpuFrame->data,
       cpuFrame->linesize);
   sws_freeContext(swsCtx);
+  TORCH_CHECK(
+      sws_ret >= 0,
+      "sws_scale(GBRP->NV12) failed: expected ",
+      get_ffmpeg_error_string_from_error_code(sws_ret))
+  TORCH_CHECK(
+      sws_ret == vaFrame->height,
+      "sws_scale(GBRP->NV12) failed: expected ", sws_ret,
+      "output lines, expected", vaFrame->height);
 
   // Upload CPU NV12 -> VAAPI surface
   ret = av_hwframe_transfer_data(vaFrame.get(), cpuFrame.get(), 0);

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -623,14 +623,13 @@ std::optional<const AVCodec*> XpuDeviceInterface::find_codec(
     return nullptr;
   };
 
-  // 1) Try the requested codec id first.
+  // Try the requested codec id first.
   if (const AVCodec* c = findVaapiForId(codec_id)) {
     return c;
   }
 
-  // 2) Encoder-only fallback: if no VAAPI encoder exists for codecId
-  // (e.g. mp4's default MPEG4), substitute a HW-capable alternative so
-  // avcodec_open2 doesn't fail on a SW or non-VAAPI HW encoder.
+  // Encoder-only fallback: if no VAAPI encoder exists for codecId
+  // substitute a HW-capable alternative 
   if (!is_decoder) {
     static constexpr AVCodecID kHwEncoderFallbacks[] = {
         AV_CODEC_ID_H264,

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.cpp
@@ -3,6 +3,7 @@
 
 #include <unistd.h>
 #include <stdlib.h>
+#include <cstdio>
 #include <string>
 #include <unordered_map>
 
@@ -135,18 +136,66 @@ torch::stable::Tensor allocate_empty_hwc_tensor(
       device);
 }
 
+// Allocates a VAAPI-backed NV12 AVFrame for encoding by pulling a buffer from
+// the codec's hw_frames_ctx pool created in setupHardwareFrameContextForEncoding.
+UniqueAVFrame allocNV12Frame(
+    int width,
+    int height,
+    int frame_index,
+    AVCodecContext* codec_context) {
+  TORCH_CHECK(codec_context != nullptr, "codec_context is null");
+  TORCH_CHECK(
+      codec_context->hw_frames_ctx != nullptr,
+      "hw_frames_ctx is null: call setupHardwareFrameContextForEncoding first");
+
+  UniqueAVFrame vaFrame(av_frame_alloc());
+  TORCH_CHECK(vaFrame != nullptr, "Failed to allocate AVFrame for encoding");
+  vaFrame->format = AV_PIX_FMT_VAAPI;
+  vaFrame->width  = width;
+  vaFrame->height = height;
+  vaFrame->pts    = frame_index;
+
+  int ret = av_hwframe_get_buffer(codec_context->hw_frames_ctx, vaFrame.get(), 0);
+  TORCH_CHECK(
+      ret >= 0,
+      "av_hwframe_get_buffer failed: ",
+      get_ffmpeg_error_string_from_error_code(ret));
+  return vaFrame;
+}
+
+// Drains the global VAAPI hwdevice cache. Must be called from Python at
+// interpreter shutdown (via atexit) so that av_buffer_unref() -> vaTerminate()
+// runs while the SYCL / Level Zero / UR runtimes are still alive. Letting the
+// C++ static destructor of g_cached_hw_device_ctxs run at process exit gives
+// undefined ordering vs torch's XPU teardown and typically segfaults inside
+// libva / iHD_drv_video.so on Intel Arc / Battlemage.
+void drain_cached_hw_device_ctxs() noexcept {
+  for (int i = 0; i < MAX_XPU_GPUS; ++i) {
+    try {
+      StableDevice device(kStableXPU, i);
+      // Each pop returns a unique_ptr; when it goes out of scope at the end
+      // of the loop iteration, its custom deleter calls av_buffer_unref().
+      while (auto ctx = g_cached_hw_device_ctxs.get(device)) {
+        (void)ctx;
+      }
+    } catch (...) {
+      // Called from atexit; must never throw across the C ABI boundary.
+    }
+  }
+}
+
 } // namespace xpu
 
 int get_device_index(const StableDevice& device) {
   // PyTorch uses int8_t as its torch::DeviceIndex, but FFmpeg and XPU
   // libraries use int. So we use int, too.
-  int deviceIndex = static_cast<int>(device.index());
+  int device_index = static_cast<int>(device.index());
   TORCH_CHECK(
-      deviceIndex >= -1 && deviceIndex < xpu::MAX_XPU_GPUS,
+      device_index >= -1 && device_index < xpu::MAX_XPU_GPUS,
       "Invalid device index = ",
-      deviceIndex);
+      device_index);
 
-  return (deviceIndex == -1)? 0: deviceIndex;
+  return (device_index == -1)? 0: device_index;
 }
 
 XpuDeviceInterface::XpuDeviceInterface(const StableDevice& device)
@@ -547,24 +596,55 @@ bool XpuDeviceInterface::convert_av_frame_to_frame_output_with_sycl(
 std::optional<const AVCodec*> XpuDeviceInterface::find_codec(
     const AVCodecID& codec_id,
     bool is_decoder) {
+  // Look up the first codec (decoder or encoder) registered for `id` that
+  // advertises a VAAPI hw_config.
+  auto findVaapiForId = [is_decoder](AVCodecID id) -> const AVCodec* {
   void* i = nullptr;
   const AVCodec* codec = nullptr;
   while ((codec = av_codec_iterate(&i)) != nullptr) {
     if (is_decoder) {
-      if (codec->id != codec_id || !av_codec_is_decoder(codec)) {
+      if (codec->id != id || !av_codec_is_decoder(codec)) {
         continue;
       }
     } else {
-      if (codec->id != codec_id || !av_codec_is_encoder(codec)) {
+      if (codec->id != id || !av_codec_is_encoder(codec)) {
         continue;
       }
     }
 
-    const AVCodecHWConfig* config = nullptr;
-    for (int j = 0; (config = avcodec_get_hw_config(codec, j)) != nullptr;
-         ++j) {
-      if (config->device_type == AV_HWDEVICE_TYPE_VAAPI) {
-        return codec;
+      const AVCodecHWConfig* config = nullptr;
+      for (int j = 0; (config = avcodec_get_hw_config(codec, j)) != nullptr;
+           ++j) {
+        if (config->device_type == AV_HWDEVICE_TYPE_VAAPI) {
+          return codec;
+        }
+      }
+    }
+    return nullptr;
+  };
+
+  // 1) Try the requested codec id first.
+  if (const AVCodec* c = findVaapiForId(codec_id)) {
+    return c;
+  }
+
+  // 2) Encoder-only fallback: if no VAAPI encoder exists for codecId
+  // (e.g. mp4's default MPEG4), substitute a HW-capable alternative so
+  // avcodec_open2 doesn't fail on a SW or non-VAAPI HW encoder.
+  if (!is_decoder) {
+    static constexpr AVCodecID kHwEncoderFallbacks[] = {
+        AV_CODEC_ID_H264,
+        AV_CODEC_ID_HEVC,
+        AV_CODEC_ID_AV1,
+    };
+    for (AVCodecID fb : kHwEncoderFallbacks) {
+      if (fb == codec_id) {
+        continue;
+      }
+      if (const AVCodec* c = findVaapiForId(fb)) {
+        VLOG(1) << "No VAAPI encoder for codec id " << codec_id
+                << ", substituting " << c->name;
+        return c;
       }
     }
   }
@@ -572,4 +652,318 @@ std::optional<const AVCodec*> XpuDeviceInterface::find_codec(
   return std::nullopt;
 }
 
+// ============================================================
+// Encoding: getEncodingPixelFormat
+// ============================================================
+// XPU encoders (VAAPI) consume NV12. We reject any user-supplied pixel
+// format and force NV12 to match the VAAPI hw_frames_ctx sw_format below.
+AVPixelFormat XpuDeviceInterface::get_encoding_pixel_format(
+    [[maybe_unused]] const AVCodec& av_codec,
+    const std::optional<std::string>& user_pixel_format) const {
+  STD_TORCH_CHECK(
+      !user_pixel_format.has_value(),
+      "Video encoding on XPU currently only supports the nv12 pixel format. "
+      "Do not set pixel_format to use nv12 by default.");
+  return AV_PIX_FMT_NV12;
+}
+
+// ============================================================
+// Encoding: setupHardwareFrameContextForEncoding
+// ============================================================
+// Allocates a VAAPI hw_frames_ctx on the codec context so the encoder
+// can write directly into VAAPI surfaces (NV12 layout, VAAPI wrapper).
+void XpuDeviceInterface::setup_hardware_frame_context_for_encoding(
+    AVCodecContext* codec_context) {
+  TORCH_CHECK(
+      ctx_,
+      "VAAPI hw device context is not initialized. "
+      "This device may not have a media engine (e.g. PVC/Ponte Vecchio). "
+      "Encoding via XPU is only supported on devices with VAAPI.");
+  TORCH_CHECK(codec_context != nullptr, "codec_context is null");
+
+  AVBufferRef* hwFramesCtxRef = av_hwframe_ctx_alloc(ctx_.get());
+  TORCH_CHECK(
+      hwFramesCtxRef != nullptr,
+      "Failed to allocate VAAPI hw frames context for codec");
+
+  // sw_pix_fmt: the software (CPU-accessible) format the encoder consumes inside the surface
+  // pix_fmt:    the hardware wrapper format the codec sees (must match hw_frames_ctx->format)
+  codec_context->sw_pix_fmt = AV_PIX_FMT_NV12;
+  codec_context->pix_fmt    = AV_PIX_FMT_VAAPI;
+
+  auto* hwFramesCtx = reinterpret_cast<AVHWFramesContext*>(hwFramesCtxRef->data);
+  hwFramesCtx->format    = AV_PIX_FMT_VAAPI;
+  hwFramesCtx->sw_format = AV_PIX_FMT_NV12;
+  hwFramesCtx->width     = codec_context->width;
+  hwFramesCtx->height    = codec_context->height;
+
+  // XPU quality is matterially better when using BT.709 color space and full range
+  // (JPEG) for encoding.
+  if (codec_context->color_range == AVCOL_RANGE_UNSPECIFIED) {
+      codec_context->color_range = AVCOL_RANGE_JPEG;
+  }
+  if (codec_context->colorspace == AVCOL_SPC_UNSPECIFIED) {
+      codec_context->colorspace = AVCOL_SPC_BT709;
+  }
+  if (codec_context->color_primaries == AVCOL_PRI_UNSPECIFIED) {
+      codec_context->color_primaries = AVCOL_PRI_BT709;
+  }
+  if (codec_context->color_trc == AVCOL_TRC_UNSPECIFIED) {
+      codec_context->color_trc = AVCOL_TRC_BT709;
+  }
+
+  // Force non-LP VAAPI engine for better quality under async_depth=1;
+  // caller-supplied low_power via extra_options overrides this later.
+  if (codec_context->priv_data != nullptr) {
+      av_opt_set(codec_context->priv_data, "low_power", "0",
+                 AV_OPT_SEARCH_CHILDREN);
+      // `quality=1` selects the highest-quality preset on VAAPI codecs that
+      // expose it. av_opt_set is silent on codecs that don't, so it's safe.
+      av_opt_set(codec_context->priv_data, "quality", "1",
+                 AV_OPT_SEARCH_CHILDREN);
+  }
+
+  // Disable B-frames (mirrors CUDA/NVENC delay=0) to avoid reorder issues
+  // with fragmented containers; callers can restore via extra_options={"bf":"2"}.
+  codec_context->max_b_frames = 0;
+
+  int ret = av_hwframe_ctx_init(hwFramesCtxRef);
+  if (ret < 0) {
+    av_buffer_unref(&hwFramesCtxRef);
+    TORCH_CHECK(
+        false,
+        "Failed to initialize VAAPI hw frames context: ",
+        get_ffmpeg_error_string_from_error_code(ret));
+  }
+  codec_context->hw_frames_ctx = hwFramesCtxRef;
+}
+
+// ============================================================
+// Encoding: convertTensorToAVFrameForEncoding
+// ============================================================
+UniqueAVFrame XpuDeviceInterface::convert_tensor_to_av_frame_for_encoding(
+    const torch::stable::Tensor& tensor,
+    int frame_index,
+    AVCodecContext* codec_context) {
+  TORCH_CHECK(
+      tensor.dim() == 3 && tensor.sizes()[0] == 3,
+      "Expected CHW tensor with 3 channels (RGB), got shape: ",
+      tensor.sizes()[0], "x", tensor.sizes()[1], "x", tensor.sizes()[2]);
+  TORCH_CHECK(codec_context != nullptr, "codec_context is null");
+  TORCH_CHECK(
+      codec_context->hw_frames_ctx != nullptr,
+      "hw_frames_ctx is null: call setupHardwareFrameContextForEncoding first");
+
+  // Try the optimized SYCL path first. It returns a null UniqueAVFrame when
+  // SYCL is unavailable (USE_SYCL_KERNELS disabled, no FP64 support, or built
+  // without WITH_SYCL_KERNELS). In that case, fall back to the CPU path.
+  UniqueAVFrame avFrame =
+      convert_tensor_to_av_frame_for_encoding_sycl(tensor, frame_index, codec_context);
+  if (avFrame) {
+    VLOG(9) << "[XPU Encoder] Encoding frame " << frame_index
+            << " via SYCL on device=xpu:" << device_.index();
+    return avFrame;
+  }
+
+  VLOG(9) << "[XPU Encoder] Encoding frame " << frame_index << " via CPU fallback";
+  return convert_tensor_to_av_frame_for_encoding_cpu(tensor, frame_index, codec_context);
+}
+
+// ============================================================
+// Encoding: convertTensorToAVFrameForEncoding_SYCL
+// ============================================================
+UniqueAVFrame XpuDeviceInterface::convert_tensor_to_av_frame_for_encoding_sycl(
+    [[maybe_unused]] const torch::stable::Tensor& tensor,
+    [[maybe_unused]] int frame_index,
+    [[maybe_unused]] AVCodecContext* codec_context) {
+  if (!xpu::use_sycl_color_conversion_kernel()) {
+    return UniqueAVFrame();
+  }
+  if (!has_fp64_) {
+    return UniqueAVFrame();
+  }
+
+  UniqueAVFrame vaFrame;
+#ifdef WITH_SYCL_KERNELS
+  const int width  = static_cast<int>(tensor.sizes()[2]);
+  const int height = static_cast<int>(tensor.sizes()[1]);
+  vaFrame = xpu::allocNV12Frame(width, height, frame_index, codec_context);
+
+  VADisplay display = getVaDisplayFromAV(vaFrame.get());
+  VASurfaceID surfaceId = (VASurfaceID)(uintptr_t)vaFrame->data[3];
+
+  VADRMPRIMESurfaceDescriptor desc{};
+  VAStatus sts = vaExportSurfaceHandle(
+      display,
+      surfaceId,
+      VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2,
+      VA_EXPORT_SURFACE_WRITE_ONLY,  // write for encoding (vs. READ_ONLY for decoding)
+      &desc);
+  TORCH_CHECK(
+      sts == VA_STATUS_SUCCESS,
+      "vaExportSurfaceHandle (WRITE_ONLY) failed: ",
+      vaErrorStr(sts));
+  TORCH_CHECK(desc.num_objects == 1, "Expected 1 DMA-BUF object, got ", desc.num_objects);
+  // NV12 export layouts seen on Intel iHD/i915:
+  //   A: 1 layer × 2 planes (Y, UV).   B: 2 layers × 1 plane (Y; UV) — used by BMG.
+  // Both describe the same DMA-BUF; only the plane offsets/pitches differ.
+  const bool layoutA = (desc.num_layers == 1 && desc.layers[0].num_planes == 2);
+  const bool layoutB = (desc.num_layers == 2 && desc.layers[0].num_planes == 1
+                        && desc.layers[1].num_planes == 1);
+  TORCH_CHECK(
+      layoutA || layoutB,
+      "Unsupported NV12 export layout: num_layers=", desc.num_layers,
+      " layers[0].num_planes=", desc.layers[0].num_planes);
+
+  // Get Level Zero context and device handles via SYCL interop.
+  sycl::queue queue = c10::xpu::getCurrentXPUStream(device_.index());
+  ze_context_handle_t zeCtx  = nullptr;
+  ze_device_handle_t  zeDevice = nullptr;
+  queue
+      .submit([&](sycl::handler& cgh) {
+        cgh.host_task([&](const sycl::interop_handle& ih) {
+          zeCtx    = ih.get_native_context<sycl::backend::ext_oneapi_level_zero>();
+          zeDevice = ih.get_native_device<sycl::backend::ext_oneapi_level_zero>();
+        });
+      })
+      .wait();
+
+  ze_external_memory_import_fd_t import_fd_desc{};
+  import_fd_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMPORT_FD;
+  import_fd_desc.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
+  import_fd_desc.fd    = desc.objects[0].fd;
+
+  ze_device_mem_alloc_desc_t alloc_desc{};
+  alloc_desc.pNext = &import_fd_desc;
+  void* usm_ptr = nullptr;
+  ze_result_t res = zeMemAllocDevice(
+      zeCtx, &alloc_desc, desc.objects[0].size, 0, zeDevice, &usm_ptr);
+  TORCH_CHECK(
+      res == ZE_RESULT_SUCCESS,
+      "zeMemAllocDevice failed importing encode surface fd=",
+      desc.objects[0].fd);
+
+  // Extract Y and UV plane pointers and pitches for both layouts
+  uint8_t* y_ptr;
+  uint8_t* uv_ptr;
+  int y_pitch, uv_pitch;
+  if (layoutA) {
+    y_ptr    = static_cast<uint8_t*>(usm_ptr) + desc.layers[0].offset[0];
+    uv_ptr   = static_cast<uint8_t*>(usm_ptr) + desc.layers[0].offset[1];
+    y_pitch  = static_cast<int>(desc.layers[0].pitch[0]);
+    uv_pitch = static_cast<int>(desc.layers[0].pitch[1]);
+  } else {
+    y_ptr    = static_cast<uint8_t*>(usm_ptr) + desc.layers[0].offset[0];
+    uv_ptr   = static_cast<uint8_t*>(usm_ptr) + desc.layers[1].offset[0];
+    y_pitch  = static_cast<int>(desc.layers[0].pitch[0]);
+    uv_pitch = static_cast<int>(desc.layers[1].pitch[0]);
+  }
+
+  // drm_format_modifier != 0 means tiled (e.g. Intel Tile-Y on BMG/Gen12+).
+  const bool is_tiled = (desc.objects[0].drm_format_modifier != 0);
+  convertRGBToNV12(
+      queue,
+      static_cast<const uint8_t*>(tensor.data_ptr()),
+      tensor.strides()[0],   // ch_stride
+      tensor.strides()[1],   // row_stride
+      tensor.strides()[2],   // pixel_stride
+      y_ptr,
+      uv_ptr,
+      vaFrame->width,
+      vaFrame->height,
+      y_pitch,
+      uv_pitch,
+      is_tiled,
+      codec_context->color_range,
+      codec_context->colorspace);
+
+  zeMemFree(zeCtx, usm_ptr);
+  close(desc.objects[0].fd);
+
+  vaFrame->colorspace  = codec_context->colorspace;
+  vaFrame->color_range = codec_context->color_range;
+#endif
+  return vaFrame;
+}
+
+// ============================================================
+// Encoding: convertTensorToAVFrameForEncoding_CPU  (CPU fallback)
+// ============================================================
+UniqueAVFrame XpuDeviceInterface::convert_tensor_to_av_frame_for_encoding_cpu(
+    const torch::stable::Tensor& tensor,
+    int frame_index,
+    AVCodecContext* codec_context) {
+  const int width  = static_cast<int>(tensor.sizes()[2]);
+  const int height = static_cast<int>(tensor.sizes()[1]);
+  UniqueAVFrame vaFrame =
+      xpu::allocNV12Frame(width, height, frame_index, codec_context);
+
+  // Move XPU tensor to CPU (blocking)
+  torch::stable::Tensor cpuTensor =
+      torch::stable::to(tensor, StableDevice(kStableCPU, 0));
+
+  const uint8_t* data = static_cast<const uint8_t*>(cpuTensor.data_ptr());
+  // strides() are in elements (uint8), so they equal byte strides here.
+  int64_t ch_stride  = cpuTensor.strides()[0];
+  int64_t row_stride = cpuTensor.strides()[1];
+
+  // Allocate an intermediate CPU NV12 frame for sws_scale output
+  UniqueAVFrame cpuFrame(av_frame_alloc());
+  TORCH_CHECK(cpuFrame != nullptr, "Failed to allocate CPU NV12 AVFrame");
+  cpuFrame->format = AV_PIX_FMT_NV12;
+  cpuFrame->width  = vaFrame->width;
+  cpuFrame->height = vaFrame->height;
+  int ret = av_frame_get_buffer(cpuFrame.get(), 0);
+  TORCH_CHECK(ret >= 0, "av_frame_get_buffer (NV12) failed: ",
+              get_ffmpeg_error_string_from_error_code(ret));
+
+  // Zero-copy GBRP view of the NCHW tensor (GBRP plane order: G=ch1, B=ch2, R=ch0).
+  UniqueAVFrame gbrpFrame(av_frame_alloc());
+  TORCH_CHECK(gbrpFrame != nullptr, "Failed to allocate GBRP AVFrame");
+  gbrpFrame->format = AV_PIX_FMT_GBRP;
+  gbrpFrame->width  = vaFrame->width;
+  gbrpFrame->height = vaFrame->height;
+  gbrpFrame->data[0] = const_cast<uint8_t*>(data + 1 * ch_stride);  // G
+  gbrpFrame->data[1] = const_cast<uint8_t*>(data + 2 * ch_stride);  // B
+  gbrpFrame->data[2] = const_cast<uint8_t*>(data + 0 * ch_stride);  // R
+  gbrpFrame->linesize[0] = static_cast<int>(row_stride);
+  gbrpFrame->linesize[1] = static_cast<int>(row_stride);
+  gbrpFrame->linesize[2] = static_cast<int>(row_stride);
+
+  // GBRP -> NV12 via libswscale
+  SwsContext* swsCtx = sws_getContext(
+      vaFrame->width, vaFrame->height, AV_PIX_FMT_GBRP,
+      vaFrame->width, vaFrame->height, AV_PIX_FMT_NV12,
+      SWS_BILINEAR, nullptr, nullptr, nullptr);
+  TORCH_CHECK(swsCtx != nullptr, "sws_getContext(GBRP->NV12) failed");
+  sws_scale(
+      swsCtx,
+      gbrpFrame->data,
+      gbrpFrame->linesize,
+      0,
+      vaFrame->height,
+      cpuFrame->data,
+      cpuFrame->linesize);
+  sws_freeContext(swsCtx);
+
+  // Upload CPU NV12 -> VAAPI surface
+  ret = av_hwframe_transfer_data(vaFrame.get(), cpuFrame.get(), 0);
+  TORCH_CHECK(
+      ret >= 0,
+      "av_hwframe_transfer_data (NV12->VAAPI) failed: ",
+      get_ffmpeg_error_string_from_error_code(ret));
+
+  vaFrame->colorspace  = codec_context->colorspace;
+  vaFrame->color_range = codec_context->color_range;
+  return vaFrame;
+}
+
 } // namespace facebook::torchcodec
+
+// C-ABI shutdown entry point. Discovered from Python via ctypes and registered
+// with atexit so it runs BEFORE torch's own XPU teardown handlers. See
+// facebook::torchcodec::xpu::drain_cached_hw_device_ctxs() for details.
+extern "C" __attribute__((visibility("default")))
+void torchcodec_xpu_shutdown() {
+  facebook::torchcodec::xpu::drain_cached_hw_device_ctxs();
+}

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/XpuDeviceInterface.h
@@ -37,6 +37,19 @@ class XpuDeviceInterface : public DeviceInterface {
       std::optional<torch::stable::Tensor> pre_allocated_output_tensor =
           std::nullopt) override;
 
+  // ---- Encoding overrides ----
+  UniqueAVFrame convert_tensor_to_av_frame_for_encoding(
+      const torch::stable::Tensor& tensor,
+      int frame_index,
+      AVCodecContext* codec_context) override;
+
+  AVPixelFormat get_encoding_pixel_format(
+      const AVCodec& av_codec,
+      const std::optional<std::string>& user_pixel_format) const override;
+
+  void setup_hardware_frame_context_for_encoding(
+      AVCodecContext* codec_context) override;
+
  private:
   // We sometimes encounter frames that cannot be decoded on the XPU device.
   // Rather than erroring out, we decode them on the CPU.
@@ -63,6 +76,21 @@ class XpuDeviceInterface : public DeviceInterface {
   void convert_av_frame_to_frame_output_with_filter_graph(
       UniqueAVFrame& av_frame,
       torch::stable::Tensor& dst);
+
+  // ---- Encoding helpers ----
+  // SYCL path: exports VAAPI surface as DMA-BUF, imports via Level Zero USM,
+  // runs convertRGBToNV12 directly on the surface. Returns null when SYCL
+  // is unavailable.
+  UniqueAVFrame convert_tensor_to_av_frame_for_encoding_sycl(
+      const torch::stable::Tensor& tensor,
+      int frame_index,
+      AVCodecContext* codec_context);
+  // CPU fallback: moves tensor to CPU, uses libswscale GBRP->NV12,
+  // then av_hwframe_transfer_data to upload into the VAAPI surface.
+  UniqueAVFrame convert_tensor_to_av_frame_for_encoding_cpu(
+      const torch::stable::Tensor& tensor,
+      int frame_index,
+      AVCodecContext* codec_context);
 };
 
 } // namespace facebook::torchcodec

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/__init__.py
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2025 Dmitry Rogozhkin.
 # Copyright (c) 2026 Intel Corporation. All Rights Reserved.
 
-import atexit
 import ctypes
 import importlib
 import traceback

--- a/packages/torchcodec-xpu/src/torchcodec_xpu/__init__.py
+++ b/packages/torchcodec-xpu/src/torchcodec_xpu/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Dmitry Rogozhkin.
 # Copyright (c) 2026 Intel Corporation. All Rights Reserved.
 
+import atexit
 import ctypes
 import importlib
 import traceback


### PR DESCRIPTION
Adds a hardware video encoding path to the torchcodec-xpu plugin  (supersedes #58)

What changes:

- XpuDeviceInterface.{h,cpp} — implements three encoder overrides:

 1. - get_encoding_pixel_format (pinned to NV12).
 2. - setup_hardware_frame_context_for_encoding (VAAPI hw_frames_ctx, BT.709 + JPEG-range defaults, B-frames disabled, low_power=0, quality=1).
 3. - convert_tensor_to_av_frame_for_encoding dispatching to:
  
     - - -SYCL fast path — exports the VA surface as DMA-BUF, imports via Level Zero USM, runs convertRGBToNV12 directly on the surface (handles linear + Intel Tile-Y, and both NV12 export layouts on iHD/i915).

     - - -CPU fallback — GBRP→NV12 via libswscale, then av_hwframe_transfer_data onto the VA surface. Used when SYCL is disabled or FP64 is unavailable (DG2 / ATS-M).
 5. - find_codec extended to resolve VAAPI encoders, with H.264 / HEVC / AV1 fallback when the requested codec id has no VAAPI encoder.
- ColorConversionKernel.{h,cpp} — adds convertRGBToNV12 SYCL kernel (BT.601 / BT.709, limited + full range); get_tile_offset reused for encode.

- patches/0002-Add-XPU-support-to-video-encoder-tests.patch — parametrizes upstream torchcodec encoder tests over CUDA + XPU, and primes the encoder with one frame in test_write_frames_different_devices_errors (VAAPI segfaults on empty flush; NVENC doesn't). Depends on 0001-Add-XPU-support-to-tests.patch.


Compatibility
No change to decode behavior, plugin loading, or public API.

Testing
Encoder test suite (patches 0001 + 0002) passes on Intel Arc / Battlemage.
